### PR TITLE
fix compiler error for development tool

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -58,7 +58,7 @@ configuration "devtool_release" {
     targetName "devtool"
     targetType "executable"
     buildType "debugInfo"
-    excludedSourceFiles "source/application/*.d"
+    excludedSourceFiles "source/application/app*.d"
     mainSourceFile "source/test/tok_main.d"
 }
 


### PR DESCRIPTION
changes in the structure of the application main resulted in too many files being excluded from compilation.