### PR TITLE
Fixes various problems with type deduction, performance and behavior C/C++

### DIFF
--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -39,8 +39,8 @@ import clang.Visitor;
  * s = isStatement
  * t = isTranslationUnit
  * u = isUnexposed
- * v = isValid
- * V = isVirtualBase
+ * v = isVirtualBase
+ * V = isValid
  */
 string abilities(Cursor c) {
     string s = format("%s%s%s%s%s%s%s%s%s%s%s%s", c.isAttribute ? "a" : "",

--- a/source/application/utility.d
+++ b/source/application/utility.d
@@ -176,6 +176,8 @@ struct TdIncludes {
     Regex!char strip_incl;
     private FileName[] unstripped_incls;
 
+    @disable this();
+
     this(Regex!char strip_incl) {
         this.strip_incl = strip_incl;
     }

--- a/source/application/utility.d
+++ b/source/application/utility.d
@@ -146,3 +146,74 @@ auto stripIncl(ref FileName[] incls, Regex!char re) {
     return r;
 
 }
+
+/** Includes intended for the test double. Filtered according to the user.
+ *
+ * States:
+ *  - Normal.
+ *      Start state.
+ *      File are accepted and stored in buffer.
+ *      Important that transitions FROM this state clears the internal buffer.
+ *      Rational: The other states override data that was gathered during
+ *      Normal.
+ *  - HaveRoot.
+ *      One or more roots have been found.
+ *      Replaces all "Normal".
+ *  - UserDefined.
+ *      The user have supplied a list of includes which override any detected.
+ */
+struct TdIncludes {
+    import std.regex;
+
+    enum State {
+        Normal,
+        HaveRoot,
+        UserDefined
+    }
+
+    FileName[] incls;
+    State st;
+    Regex!char strip_incl;
+    private FileName[] unstripped_incls;
+
+    this(Regex!char strip_incl) {
+        this.strip_incl = strip_incl;
+    }
+
+    /** Replace buffer of includes with argument.
+     *
+     * See description of states to understand what UserDefined entitles.
+     */
+    void forceIncludes(string[] in_incls) {
+        st = State.UserDefined;
+        foreach (incl; in_incls) {
+            incls ~= FileName(incl);
+        }
+    }
+
+    void doStrip() @safe {
+        incls ~= stripIncl(unstripped_incls, strip_incl);
+    }
+
+    void put(FileName fname, LocationType type) @safe {
+        final switch (st) with (State) {
+        case Normal:
+            if (type == LocationType.Root) {
+                unstripped_incls = [fname];
+                st = HaveRoot;
+            } else {
+                unstripped_incls ~= fname;
+            }
+            break;
+        case HaveRoot:
+            // only accepting roots
+            if (type == LocationType.Root) {
+                unstripped_incls ~= fname;
+            }
+            break;
+        case UserDefined:
+            // ignoring new includes
+            break;
+        }
+    }
+}

--- a/source/cpptooling/analyzer/clang/utility.d
+++ b/source/cpptooling/analyzer/clang/utility.d
@@ -1,0 +1,165 @@
+// Written in the D programming language.
+/**
+Date: 2015, Joakim Brännström
+License: GPL
+Author: Joakim Brännström (joakim.brannstrom@gmx.com)
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
+module cpptooling.analyzer.clang.utility;
+
+import logger = std.experimental.logger;
+
+import clang.Cursor;
+
+/** Travers a node tree and gather all paramdecl to an array.
+ * Params:
+ * T = Type that shall wrap TypeKindVariable.
+ * cursor = A node containing ParmDecl nodes as children.
+ * Example:
+ * -----
+ * class Simple{ Simple(char x, char y); }
+ * -----
+ * The AST for the above is kind of the following:
+ * Example:
+ * ---
+ * Simple [CXCursor_Constructor Type(CXType(CXType_FunctionProto))
+ *   x [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
+ *   y [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
+ * ---
+ * It is translated to the array [("char", "x"), ("char", "y")].
+ */
+auto paramDeclTo(Cursor cursor) {
+    import cpptooling.analyzer.clang.type : TypeKind, translateType;
+    import cpptooling.data.representation : TypeKindVariable, CppVariable,
+        makeCxParam, CxParam, VariadicType;
+
+    CxParam[] params;
+
+    if (cursor.type.isTypedef) {
+        // handles the following case.
+        // typedef unsigned char (func_type) (const unsigned int baz);
+        // extern func_ptr hest;
+        // Must grab the underlying type and parse the arguments.
+        // TODO investigate if the fixes to translateUnexposed can improve the
+        // param extraction here to allow grabbing of the underlying types
+        // identifier name.
+        cursor = cursor.type.declaration;
+        foreach (arg; cursor.type.func.arguments) {
+            auto type = translateType(arg);
+            params ~= makeCxParam(TypeKindVariable(type.unwrap, CppVariable("")));
+        }
+    } else {
+        foreach (param; cursor.func.parameters) {
+            auto type = translateType(param.type);
+            params ~= makeCxParam(TypeKindVariable(type.unwrap, CppVariable(param.spelling)));
+        }
+    }
+
+    if (cursor.func.isVariadic) {
+        params ~= makeCxParam();
+    }
+
+    debug {
+        import std.variant : visit;
+
+        foreach (p; params) {
+            // dfmt off
+            () @trusted {
+                p.visit!((TypeKindVariable p) => logger.trace(p.type.txt, ":", cast(string) p.name),
+                         (TypeKind p) => logger.trace(p.txt),
+                         (VariadicType p) => logger.trace("..."));
+            }();
+            // dfmt on
+        }
+    }
+
+    return params;
+}
+
+import cpptooling.analyzer.clang.type;
+import std.typecons : Tuple;
+
+alias PTuple = Tuple!(WrapTypeKind, "wtk", string, "id");
+
+//TODO duplicate code in paramDeclTo, reuse this implementation.
+auto extractParams(Cursor cursor, bool is_variadic) {
+    import std.typecons : tuple, Tuple;
+
+    PTuple[] params;
+
+    if (cursor.type.isTypedef) {
+        // handles the following case.
+        // typedef unsigned char (func_type) (const unsigned int baz);
+        // extern func_ptr hest;
+        // Must grab the underlying type and parse the arguments.
+        // TODO investigate if the fixes to translateUnexposed can improve the
+        // param extraction here to allow grabbing of the underlying types
+        // identifier name.
+        cursor = cursor.type.declaration;
+        foreach (arg; cursor.type.func.arguments) {
+            auto type = translateType(arg);
+            params ~= PTuple(type, "");
+        }
+    } else {
+        foreach (param; cursor.func.parameters) {
+            auto type = translateType(param.type);
+            params ~= PTuple(type, param.spelling);
+        }
+    }
+
+    if (is_variadic) {
+        auto wtk = WrapTypeKind();
+        wtk.typeKind = makeTypeKind("", false, false, false);
+        wtk.typeKind.info = TypeKind.SimpleInfo("%s");
+        params ~= PTuple(wtk, "...");
+    }
+
+    debug {
+        import std.variant : visit;
+
+        foreach (p; params) {
+            // dfmt off
+            () @trusted {
+                logger.trace(p.wtk.typeKind.txt, ":", cast(string) p.id);
+            }();
+            // dfmt on
+        }
+    }
+
+    return params;
+}
+
+/// Join an array slice of PTuples to a parameter string of "type" "id"
+string joinParamNames(PTuple[] r) @safe {
+    import std.algorithm : joiner, map, filter;
+    import std.conv : text;
+    import std.range : enumerate;
+
+    static string getTypeId(PTuple p, ulong uid) @trusted {
+        import std.variant : visit;
+
+        if (p.id == "") {
+            return p.wtk.typeKind.toString("x" ~ text(uid));
+        } else {
+            return p.wtk.typeKind.toString(p.id);
+        }
+    }
+
+    // using cache to avoid calling getName twice.
+    return r.enumerate.map!(a => getTypeId(a.value, a.index)).filter!(a => a.length > 0).joiner(
+        ", ").text();
+
+}

--- a/source/cpptooling/analyzer/clang/visitor.d
+++ b/source/cpptooling/analyzer/clang/visitor.d
@@ -363,10 +363,9 @@ struct NamespaceVisitor {
     }
 
     bool apply(ref Cursor c, ref Cursor parent) {
-        logNode(c, 0);
-
         switch (c.kind) with (CXCursorKind) {
         case CXCursor_Namespace:
+            logNode(c, 0);
             data.put(NamespaceVisitor.make(c, stack).visit(c));
             break;
         default:

--- a/source/cpptooling/analyzer/clang/visitor.d
+++ b/source/cpptooling/analyzer/clang/visitor.d
@@ -26,6 +26,7 @@ import deimos.clang.index;
 import clang.Cursor;
 import clang.SourceLocation;
 
+import cpptooling.analyzer.clang.utility;
 import cpptooling.data.representation : AccessType;
 import cpptooling.utility.clang : visitAst, logNode;
 
@@ -438,68 +439,4 @@ struct ParseContext {
     }
 
     CppRoot root;
-}
-
-private:
-
-/** Travers a node tree and gather all paramdecl to an array.
- * Params:
- * T = Type that shall wrap TypeKindVariable.
- * cursor = A node containing ParmDecl nodes as children.
- * Example:
- * -----
- * class Simple{ Simple(char x, char y); }
- * -----
- * The AST for the above is kind of the following:
- * Example:
- * ---
- * Simple [CXCursor_Constructor Type(CXType(CXType_FunctionProto))
- *   x [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
- *   y [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
- * ---
- * It is translated to the array [("char", "x"), ("char", "y")].
- */
-auto paramDeclTo(Cursor cursor) {
-    import cpptooling.analyzer.clang.type : TypeKind, translateType;
-    import cpptooling.data.representation : TypeKindVariable, CppVariable,
-        makeCxParam, CxParam, VariadicType;
-
-    CxParam[] params;
-
-    if (cursor.type.isTypedef) {
-        // handles the following case.
-        // typedef unsigned char (func_type) (const unsigned int baz);
-        // extern func_ptr hest;
-        // Must grab the underlying type and parse the arguments.
-        cursor = cursor.type.declaration;
-        foreach (arg; cursor.type.func.arguments) {
-            auto type = translateType(arg);
-            params ~= makeCxParam(TypeKindVariable(type.unwrap, CppVariable("")));
-        }
-    } else {
-        foreach (param; cursor.func.parameters) {
-            auto type = translateType(param.type);
-            params ~= makeCxParam(TypeKindVariable(type.unwrap, CppVariable(param.spelling)));
-        }
-    }
-
-    if (cursor.func.isVariadic) {
-        params ~= makeCxParam();
-    }
-
-    debug {
-        import std.variant : visit;
-
-        foreach (p; params) {
-            // dfmt off
-            () @trusted {
-                p.visit!((TypeKindVariable p) => logger.trace(p.type.txt, ":", cast(string) p.name),
-                         (TypeKind p) => logger.trace(p.txt),
-                         (VariadicType p) => logger.trace("..."));
-            }();
-            // dfmt on
-        }
-    }
-
-    return params;
 }

--- a/source/cpptooling/analyzer/type.d
+++ b/source/cpptooling/analyzer/type.d
@@ -96,6 +96,11 @@ pure @safe nothrow @nogc struct TypeKind {
             txt_ = s;
     }
 
+    /// Crucial that the representation is correct.
+    auto unsafeForceTxt(string s) {
+        txt_ = s;
+    }
+
 private:
     string txt_;
 }

--- a/source/cpptooling/generator/cppvariant.d
+++ b/source/cpptooling/generator/cppvariant.d
@@ -270,27 +270,28 @@ CppRoot rawFilter(CppRoot input, Controller ctrl, Products prod) {
     import std.algorithm : among, each, filter;
     import cpptooling.data.representation : VirtualType;
 
-    auto tr = CppRoot(input.location);
+    auto raw = CppRoot(input.location);
 
     if (ctrl.doFile(input.location.file, "root " ~ input.location.toString)) {
         prod.putLocation(FileName(input.location.file), LocationType.Root);
     }
 
-    // Assuming that namespaces can are never duplicated at this stage.
+    // Assuming that namespaces are never duplicated at this stage.
+    // The assumtion comes from the structore of the AST.
     // dfmt off
     input.namespaceRange
         .filter!(a => !a.isAnonymous)
-        .each!(a => tr.put(rawFilter(a, ctrl, prod)));
+        .each!(a => raw.put(rawFilter(a, ctrl, prod)));
 
     if (ctrl.doGoogleMock) {
         input.classRange
             .filter!(a => a.virtualType.among(VirtualType.Pure, VirtualType.Yes))
             .filter!(a => ctrl.doFile(a.location.file, cast(string) a.name ~ " " ~ a.location.toString))
-            .each!((a) {prod.putLocation(FileName(a.location.file), LocationType.Leaf); tr.put(a);});
+            .each!((a) {prod.putLocation(FileName(a.location.file), LocationType.Leaf); raw.put(a);});
     }
     // dfmt on
 
-    return tr;
+    return raw;
 }
 
 /// Recursive filtering of namespaces to remove everything except free functions.

--- a/source/cpptooling/generator/cppvariant.d
+++ b/source/cpptooling/generator/cppvariant.d
@@ -149,13 +149,13 @@ struct Generator {
 
     /** Process structural data to a test double.
      *
-     * translate -> intermediate -> code generation.
+     * raw -> filter -> translate -> code gen.
      *
-     * translate filters the structural data.
+     * filters the structural data.
      * Controller is involved to allow filtering of identifiers in files.
      *
-     * Intermediate analyzes what is left after filtering.
-     * On demand extra data is created.
+     * translate prepares the data for code generator.
+     * On demand extra data is created. An example of on demand is --gmock.
      *
      * Code generation is a straight up translation.
      * Logical decisions should have been handled in earlier stages.

--- a/source/cpptooling/generator/func.d
+++ b/source/cpptooling/generator/func.d
@@ -26,7 +26,7 @@ import logger = std.experimental.logger;
 
 import dsrcgen.cpp : CppModule;
 
-import application.types : MainInterface;
+import application.types : MainInterface, LocationType;
 import cpptooling.data.representation : CFunction, CppClass;
 
 @safe:
@@ -38,9 +38,9 @@ auto rawFilter(ControllerT, ProductsT)(CFunction func, ControllerT ctrl, Product
 
     NullableVoid!CFunction r;
 
-    if (ctrl.doFile(func.location.file)) {
+    if (ctrl.doFile(func.location.file, func.toString)) {
         r = func;
-        prod.putLocation(FileName(func.location.file));
+        prod.putLocation(FileName(func.location.file), LocationType.Leaf);
     } else {
         logger.info("Ignoring function: ", func.toString);
     }

--- a/source/cpptooling/generator/stub/cstub.d
+++ b/source/cpptooling/generator/stub/cstub.d
@@ -147,17 +147,18 @@ struct StubGenerator {
      * Controller is involved to allow filtering of identifiers in files.
      *
      * Intermediate analyzes what is left after filtering.
-     * On demand extra data is created.
+     * On demand extra data is created. An example of on demand is --gmock.
      *
      * Code generation is a straight up translation.
      * Logical decisions should have been handled in earlier stages.
      *
      * TODO refactor the control flow. Especially the gmock part.
+     * TODO rename translate to rawFilter. See cppvariant.
      */
     auto process(CppRoot root) {
         import cpptooling.data.representation : CppNamespace, CppNs;
 
-        logger.trace("Raw data:\n" ~ root.toString());
+        logger.trace("Raw:\n" ~ root.toString());
         auto tr = .translate(root, ctrl, products);
 
         // Does it have any C functions?

--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -123,7 +123,7 @@ void stage2() {
             break;
         case "param_exclude_match_all.h":
             runDextool(input_ext,
-                params ~ ["--file-exclude=.*/param_exclude_match_all.",
+                params ~ ["--file-exclude=.*/param_exclude_match_all.*",
                 `--file-exclude='.*/include/b\.c'`], incls);
             break;
         case "param_exclude_one_file.h":

--- a/test/testdata/cpp/dev/class_interface_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_interface_gmock.hpp.ref
@@ -9,11 +9,11 @@ public:
     MOCK_METHOD0(func1, int());
     MOCK_METHOD1(func2, void(int x));
     MOCK_METHOD1(func2, void(double x));
-    MOCK_METHOD1(func2, void(double * x));
+    MOCK_METHOD1(func2, void(double *x));
     MOCK_METHOD2(func3, void(long x, long y));
     MOCK_METHOD1(func3, void(long x));
-    MOCK_METHOD1(opAssign, void(const Simple & other));
-    virtual void operator=(const Simple & other) {
+    MOCK_METHOD1(opAssign, void(const Simple &other));
+    virtual void operator=(const Simple &other) {
         opAssign(other);
     }
     MOCK_METHOD1(opAssign, int(int other));

--- a/test/testdata/cpp/dev/class_variants_interface.hpp
+++ b/test/testdata/cpp/dev/class_variants_interface.hpp
@@ -3,9 +3,13 @@
 
 namespace no_inherit {
 
-class JustACtorSoVirtual {
+// both generating a mock and NOT generating one is ok.
+// the important to test is:
+//  - if a mock is generated then the d'tor is NOT virtual.
+//  - if a mock is generated it is valid.
+class JustACtor {
 public:
-    JustACtorSoVirtual();
+    JustACtor();
 };
 
 class NotVirtualWithDtor {

--- a/test/testdata/cpp/dev/class_variants_interface_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_variants_interface_gmock.hpp.ref
@@ -5,12 +5,6 @@
 
 namespace no_inherit {
 namespace TestDouble {
-class MockJustACtorSoVirtual : public JustACtorSoVirtual {
-public:
-};
-} //NS:TestDouble
-
-namespace TestDouble {
 class MockVirtualWithDtor : public VirtualWithDtor {
 public:
 };

--- a/test/testdata/cpp/dev/functions.hpp
+++ b/test/testdata/cpp/dev/functions.hpp
@@ -37,7 +37,7 @@ typedef struct Something_Big {
 extern void fun(func_ptr2 p, Something_Big b);
 
 // expect a correct call signature for a function ptr
-void func_ptr_arg(int (*a)(int, int) , int b);
+void func_ptr_arg(int (*a)(int p, int) , int b);
 
 // C++ testing
 void func_ref(int& a);

--- a/test/testdata/cpp/dev/functions.hpp
+++ b/test/testdata/cpp/dev/functions.hpp
@@ -45,7 +45,7 @@ int& func_return_ref();
 void func_ref_many(int& a, char& b);
 void func_array(int a[10]);
 void func_ref_ptr(int*& a);
-// void func_ref_array(int (&a)[10]);
+void func_ref_array(int (&a)[10]);
 
 } // NS: ns
 #endif // FUNCTIONS_H

--- a/test/testdata/cpp/dev/functions.hpp.ref
+++ b/test/testdata/cpp/dev/functions.hpp.ref
@@ -16,16 +16,17 @@ public:
     virtual void c_func_two_named(const int a, const int b) = 0;
     virtual void c_func_three_named(const int a, const int b, const int c) = 0;
     virtual void func_variadic() = 0;
-    virtual int func_variadic_one_unnamed(char * x0) = 0;
+    virtual int func_variadic_one_unnamed(char *x0) = 0;
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;
     virtual void func_ptr_arg(int (*a )(int ,int ), int b) = 0;
-    virtual void func_ref(int & a) = 0;
+    virtual void func_ref(int &a) = 0;
     virtual int & func_return_ref() = 0;
-    virtual void func_ref_many(int & a, char & b) = 0;
+    virtual void func_ref_many(int &a, char &b) = 0;
     virtual void func_array(int a[10]) = 0;
-    virtual void func_ref_ptr(int *& a) = 0;
+    virtual void func_ref_ptr(int *&a) = 0;
+    virtual void func_ref_array(int (&a)[10]) = 0;
 };
 
 ///

--- a/test/testdata/cpp/dev/functions.hpp.ref
+++ b/test/testdata/cpp/dev/functions.hpp.ref
@@ -20,7 +20,7 @@ public:
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;
-    virtual void func_ptr_arg(int (*a )(int ,int ), int b) = 0;
+    virtual void func_ptr_arg(int (*a)(int p, int x1), int b) = 0;
     virtual void func_ref(int &a) = 0;
     virtual int & func_return_ref() = 0;
     virtual void func_ref_many(int &a, char &b) = 0;

--- a/test/testdata/cpp/dev/functions_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/functions_gmock.hpp.ref
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD1(func_extern, int(int out));
     MOCK_METHOD2(unnamed_params, void(int x0, int x1));
     MOCK_METHOD2(fun, void(func_ptr2 p, Something_Big b));
-    MOCK_METHOD2(func_ptr_arg, void(int (*a )(int ,int ), int b));
+    MOCK_METHOD2(func_ptr_arg, void(int (*a)(int p, int x1), int b));
     MOCK_METHOD1(func_ref, void(int &a));
     MOCK_METHOD0(func_return_ref, int &());
     MOCK_METHOD2(func_ref_many, void(int &a, char &b));

--- a/test/testdata/cpp/dev/functions_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/functions_gmock.hpp.ref
@@ -17,16 +17,17 @@ public:
     MOCK_METHOD2(c_func_two_named, void(const int a, const int b));
     MOCK_METHOD3(c_func_three_named, void(const int a, const int b, const int c));
     MOCK_METHOD0(func_variadic, void());
-    MOCK_METHOD1(func_variadic_one_unnamed, int(char * x0));
+    MOCK_METHOD1(func_variadic_one_unnamed, int(char *x0));
     MOCK_METHOD1(func_extern, int(int out));
     MOCK_METHOD2(unnamed_params, void(int x0, int x1));
     MOCK_METHOD2(fun, void(func_ptr2 p, Something_Big b));
     MOCK_METHOD2(func_ptr_arg, void(int (*a )(int ,int ), int b));
-    MOCK_METHOD1(func_ref, void(int & a));
+    MOCK_METHOD1(func_ref, void(int &a));
     MOCK_METHOD0(func_return_ref, int &());
-    MOCK_METHOD2(func_ref_many, void(int & a, char & b));
+    MOCK_METHOD2(func_ref_many, void(int &a, char &b));
     MOCK_METHOD1(func_array, void(int a[10]));
-    MOCK_METHOD1(func_ref_ptr, void(int *& a));
+    MOCK_METHOD1(func_ref_ptr, void(int *&a));
+    MOCK_METHOD1(func_ref_array, void(int (&a)[10]));
 };
 } //NS:TestDouble
 

--- a/test/testdata/cstub/stage_1/arrays_global.cpp.ref
+++ b/test/testdata/cstub/stage_1/arrays_global.cpp.ref
@@ -20,4 +20,4 @@ int TEST_INIT_extern_a;
 int TEST_INIT_extern_b;
 int TEST_INIT_extern_c;
 char TEST_INIT_extern_incmpl;
-const char *const TEST_INIT_extern_const_incmpl;
+const char *const  TEST_INIT_extern_const_incmpl;

--- a/test/testdata/cstub/stage_1/const_global.cpp.ref
+++ b/test/testdata/cstub/stage_1/const_global.cpp.ref
@@ -27,9 +27,9 @@
 
 const int TEST_INIT_a;
 const int * TEST_INIT_b;
-int *const TEST_INIT_c;
-const int *const TEST_INIT_d;
+int *const  TEST_INIT_c;
+const int *const  TEST_INIT_d;
 const int *const * TEST_INIT_e;
-const int *const *const TEST_INIT_f;
-int *const *const TEST_INIT_g;
+const int *const *const  TEST_INIT_f;
+int *const *const  TEST_INIT_g;
 const Foo TEST_INIT_bar;

--- a/test/testdata/cstub/stage_1/function_pointers_global.cpp.ref
+++ b/test/testdata/cstub/stage_1/function_pointers_global.cpp.ref
@@ -25,11 +25,11 @@
 #define TEST_INIT_hest hest
 #endif // TEST_INIT_hest
 
-void (*e_a )(void ) TEST_INIT_e_a;
-int (*e_b )(void ) TEST_INIT_e_b;
-void (*e_c )(int ) TEST_INIT_e_c;
-void (*const e_d )(void ) TEST_INIT_e_d;
-int (*e_e )(int ,int ) TEST_INIT_e_e;
-int (*e_f )(int pa ,int pb ) TEST_INIT_e_f;
-int (*e_g )(int pa ,int pb ,...) TEST_INIT_e_g;
+void (*e_a)() TEST_INIT_e_a;
+int (*e_b)() TEST_INIT_e_b;
+void (*e_c)(int x0) TEST_INIT_e_c;
+void (*const e_d)() TEST_INIT_e_d;
+int (*e_e)(int x0, int x1) TEST_INIT_e_e;
+int (*e_f)(int pa, int pb) TEST_INIT_e_f;
+int (*e_g)(int pa, int pb, ...) TEST_INIT_e_g;
 func_ptr TEST_INIT_hest;

--- a/test/testdata/cstub/stage_1/functions.cpp.ref
+++ b/test/testdata/cstub/stage_1/functions.cpp.ref
@@ -72,7 +72,7 @@ void fun(func_ptr2 p, Something_Big b) {
     test_double_inst->fun(p, b);
 }
 
-void func_ptr_arg(int (*a )(int ,int ), int b) {
+void func_ptr_arg(int (*a)(int p, int x1), int b) {
     test_double_inst->func_ptr_arg(a, b);
 }
 

--- a/test/testdata/cstub/stage_1/functions.cpp.ref
+++ b/test/testdata/cstub/stage_1/functions.cpp.ref
@@ -56,7 +56,7 @@ void func_variadic() {
     test_double_inst->func_variadic();
 }
 
-int func_variadic_one_unnamed(char * x0, ...) {
+int func_variadic_one_unnamed(char *x0, ...) {
     return test_double_inst->func_variadic_one_unnamed(x0);
 }
 

--- a/test/testdata/cstub/stage_1/functions.h
+++ b/test/testdata/cstub/stage_1/functions.h
@@ -35,5 +35,5 @@ typedef struct Something_Big {
 extern void fun(func_ptr2 p, Something_Big b);
 
 // expect a correct call signature for a function ptr
-void func_ptr_arg(int (*a)(int, int) , int b);
+void func_ptr_arg(int (*a)(int p, int) , int b);
 #endif // FUNCTIONS_H

--- a/test/testdata/cstub/stage_1/functions.hpp.ref
+++ b/test/testdata/cstub/stage_1/functions.hpp.ref
@@ -17,7 +17,7 @@ public:
     virtual void c_func_two_named(const int a, const int b) = 0;
     virtual void c_func_three_named(const int a, const int b, const int c) = 0;
     virtual void func_variadic() = 0;
-    virtual int func_variadic_one_unnamed(char * x0) = 0;
+    virtual int func_variadic_one_unnamed(char *x0) = 0;
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;

--- a/test/testdata/cstub/stage_1/functions.hpp.ref
+++ b/test/testdata/cstub/stage_1/functions.hpp.ref
@@ -21,7 +21,7 @@ public:
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;
-    virtual void func_ptr_arg(int (*a )(int ,int ), int b) = 0;
+    virtual void func_ptr_arg(int (*a)(int p, int x1), int b) = 0;
 };
 
 ///

--- a/test/testdata/cstub/stage_1/param_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock.hpp.ref
@@ -20,7 +20,7 @@ public:
     virtual void c_func_two_named(const int a, const int b) = 0;
     virtual void c_func_three_named(const int a, const int b, const int c) = 0;
     virtual void func_variadic() = 0;
-    virtual int func_variadic_one_unnamed(char * x0) = 0;
+    virtual int func_variadic_one_unnamed(char *x0) = 0;
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;

--- a/test/testdata/cstub/stage_1/param_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock.hpp.ref
@@ -23,7 +23,7 @@ public:
     virtual int func_extern(int out) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
     virtual void fun(func_ptr2 p, Something_Big b) = 0;
-    virtual void func_ptr_arg(int (*a )(int ,int ), int b) = 0;
+    virtual void func_ptr_arg(int (*a)(int p, int x1), int b) = 0;
 };
 
 ///

--- a/test/testdata/cstub/stage_1/param_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock.hpp.ref
@@ -1,8 +1,7 @@
 #ifndef test_double_hpp
 #define test_double_hpp
 extern "C" {
-#include "function_pointers.h"
-#include "functions.h"
+#include "param_gmock.h"
 }
 
 namespace TestDouble {

--- a/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
@@ -18,7 +18,7 @@ public:
     MOCK_METHOD2(c_func_two_named, void(const int a, const int b));
     MOCK_METHOD3(c_func_three_named, void(const int a, const int b, const int c));
     MOCK_METHOD0(func_variadic, void());
-    MOCK_METHOD1(func_variadic_one_unnamed, int(char * x0));
+    MOCK_METHOD1(func_variadic_one_unnamed, int(char *x0));
     MOCK_METHOD1(func_extern, int(int out));
     MOCK_METHOD2(unnamed_params, void(int x0, int x1));
     MOCK_METHOD2(fun, void(func_ptr2 p, Something_Big b));

--- a/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
@@ -22,7 +22,7 @@ public:
     MOCK_METHOD1(func_extern, int(int out));
     MOCK_METHOD2(unnamed_params, void(int x0, int x1));
     MOCK_METHOD2(fun, void(func_ptr2 p, Something_Big b));
-    MOCK_METHOD2(func_ptr_arg, void(int (*a )(int ,int ), int b));
+    MOCK_METHOD2(func_ptr_arg, void(int (*a)(int p, int x1), int b));
 };
 } //NS:TestDouble
 

--- a/test/testdata/cstub/stage_1/structs.h
+++ b/test/testdata/cstub/stage_1/structs.h
@@ -1,12 +1,15 @@
+#ifndef STRUCTS_H
+#define STRUCTS_H
+
 struct Foo {
     int a;
 };
 
-struct Bar {
+typedef struct Bar {
     int x;
 } b;
 
-struct Foo c;
+typedef struct Foo c;
 
 struct A {
     struct B {
@@ -32,3 +35,5 @@ struct E {
 };
 
 struct F;
+
+#endif // STRUCTS_H

--- a/test/testdata/cstub/stage_1/structs.hpp.ref
+++ b/test/testdata/cstub/stage_1/structs.hpp.ref
@@ -1,6 +1,7 @@
 #ifndef test_double_hpp
 #define test_double_hpp
 extern "C" {
+#include "structs.h"
 }
 
 #endif // test_double_hpp

--- a/test/testdata/cstub/stage_1/test_include_stdlibs.hpp.ref
+++ b/test/testdata/cstub/stage_1/test_include_stdlibs.hpp.ref
@@ -1,6 +1,7 @@
 #ifndef test_double_hpp
 #define test_double_hpp
 extern "C" {
+#include "test_include_stdlibs.h"
 }
 
 #endif // test_double_hpp

--- a/test/testdata/cstub/stage_1/unions.h
+++ b/test/testdata/cstub/stage_1/unions.h
@@ -2,11 +2,11 @@ union Foo {
     int a;
 };
 
-union Bar {
+typedef union Bar {
     int x;
 } b;
 
-union Foo c;
+typedef union Foo c;
 
 union A {
     union B {

--- a/test/testdata/cstub/stage_1/unions.hpp.ref
+++ b/test/testdata/cstub/stage_1/unions.hpp.ref
@@ -1,6 +1,7 @@
 #ifndef test_double_hpp
 #define test_double_hpp
 extern "C" {
+#include "unions.h"
 }
 
 #endif // test_double_hpp

--- a/test/testdata/cstub/stage_2/param_exclude_match_all.hpp.ref
+++ b/test/testdata/cstub/stage_2/param_exclude_match_all.hpp.ref
@@ -4,7 +4,6 @@ extern "C" {
 #include "b.h"
 #include "c.h"
 #include "d.h"
-#include "param_exclude_match_all.h"
 }
 
 namespace TestDouble {
@@ -13,7 +12,6 @@ public:
     virtual void fun_b() = 0;
     virtual void fun_c() = 0;
     virtual void fun_d() = 0;
-    virtual void fun_a() = 0;
 };
 
 ///

--- a/test/testdata/cstub/stage_2/param_restrict.hpp.ref
+++ b/test/testdata/cstub/stage_2/param_restrict.hpp.ref
@@ -1,7 +1,6 @@
 #ifndef test_double_hpp
 #define test_double_hpp
 extern "C" {
-#include "b.h"
 #include "param_restrict.h"
 }
 


### PR DESCRIPTION
Reuse algorithm from C++ regarding what headers to include in the test double.
Improve performance and correctness of class purity evaluation.
Fix identity position in types.
Simplified function pointer deduction by NOT using tokens but rather AST information.