### PR TITLE
updated dev tools to allow backtracking

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ if [[ $# -eq 0 ]]; then
     dub build -c release -b release
     dub build -c debug
     dub build -c profile -b profile
-    dub build -c devtool_release
+    dub build -c devtool -b debug
 else
     dub $@
 fi

--- a/dub.sdl
+++ b/dub.sdl
@@ -53,7 +53,7 @@ configuration "debug" {
     }
 }
 
-configuration "devtool_release" {
+configuration "devtool" {
     targetName "devtool"
     targetType "executable"
     buildType "debugInfo"


### PR DESCRIPTION
needed to understand if it was possible to use semanticParent to gather
info about namespaces a referenced class reside in.
Answer: Yes it is.