### PR TITLE
Workaround for google mock methods with more than 10 parameters

### DIFF
--- a/test/testdata/cpp/dev/class_interface_more_than_10_params.hpp
+++ b/test/testdata/cpp/dev/class_interface_more_than_10_params.hpp
@@ -1,0 +1,29 @@
+// Contains a C++ interface. Pure virtual.
+// Expecting generation of a google mock implementation.
+// Important: the other files are practically empty.
+
+class Simple {
+public:
+    Simple() {}
+    virtual ~Simple() {}
+
+    // Test that methods with 10 parameters are generated correctly.
+    virtual void func10(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10) = 0;
+
+    // Test that methods with 11 parameters are generated correctly.
+    virtual int func11(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10,
+                       int x11) = 0;
+
+    // Test that void methods with 11 parameters are generated correctly.
+    virtual void vfunc11(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10,
+                         int x11) = 0;
+
+    // Test that methods with 30 parameters are generated correctly.
+    virtual int func30(int  x1, int  x2, int  x3, int  x4, int  x5, int  x6, int  x7, int  x8, int  x9, int x10,
+                       int x11, int x12, int x13, int x14, int x15, int x16, int x17, int x18, int x19, int x20,
+                       int x21, int x22, int x23, int x24, int x25, int x26, int x27, int x28, int x29, int x30) = 0;
+
+    // Test that const methods with 12 parameters are generated correctly.
+    virtual int const_func12(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10,
+                             int x11, int x12) const = 0;
+};

--- a/test/testdata/cpp/dev/class_interface_more_than_10_params_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_interface_more_than_10_params_gmock.hpp.ref
@@ -1,0 +1,39 @@
+#ifndef test_double_gmock_hpp
+#define test_double_gmock_hpp
+#include "test_double.hpp"
+#include "gmock/gmock.h"
+
+namespace TestDouble {
+class MockSimple : public Simple {
+public:
+    MOCK_METHOD10(func10, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
+    MOCK_METHOD10(func11_part_1, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
+    MOCK_METHOD1(func11_part_2, int(int x11));
+    virtual int func11(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10, int x11) {
+        func11_part_1(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10);
+        return func11_part_2(x11);
+    }
+    MOCK_METHOD10(vfunc11_part_1, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
+    MOCK_METHOD1(vfunc11_part_2, void(int x11));
+    virtual void vfunc11(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10, int x11) {
+        vfunc11_part_1(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10);
+        vfunc11_part_2(x11);
+    }
+    MOCK_METHOD10(func30_part_1, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
+    MOCK_METHOD10(func30_part_2, void(int x11, int x12, int x13, int x14, int x15, int x16, int x17, int x18, int x19, int x20));
+    MOCK_METHOD10(func30_part_3, int(int x21, int x22, int x23, int x24, int x25, int x26, int x27, int x28, int x29, int x30));
+    virtual int func30(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10, int x11, int x12, int x13, int x14, int x15, int x16, int x17, int x18, int x19, int x20, int x21, int x22, int x23, int x24, int x25, int x26, int x27, int x28, int x29, int x30) {
+        func30_part_1(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10);
+        func30_part_2(x11, x12, x13, x14, x15, x16, x17, x18, x19, x20);
+        return func30_part_3(x21, x22, x23, x24, x25, x26, x27, x28, x29, x30);
+    }
+    MOCK_CONST_METHOD10(const_func12_part_1, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
+    MOCK_CONST_METHOD2(const_func12_part_2, int(int x11, int x12));
+    virtual int const_func12(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10, int x11, int x12) const {
+        const_func12_part_1(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10);
+        return const_func12_part_2(x11, x12);
+    }
+};
+} //NS:TestDouble
+
+#endif // test_double_gmock_hpp


### PR DESCRIPTION
Make it possible to mock methods with more than 10 parameters

Mock methods for interface methods with more than 10 parameters are split into 
several partial mock methods. User of mock object can set expectations on each
partial mock method. Return values should be set for the last partial mock method.

Fix for issue #21 