### PR TITLE
Bug: add generation of virtual destructor to gmocks

### DIFF
--- a/source/cpptooling/generator/gmock.d
+++ b/source/cpptooling/generator/gmock.d
@@ -38,6 +38,7 @@ in {
     assert(in_c.virtualType.among(VirtualType.Pure, VirtualType.Yes));
 }
 body {
+    import std.ascii : newline;
     import std.algorithm : each;
     import std.conv : text;
     import std.format : format;
@@ -182,6 +183,7 @@ body {
     ns.suppressIndent(1);
     auto c = ns.class_("Mock" ~ in_c.name().str, "public " ~ in_c.name().str);
     auto pub = c.public_();
+    pub.dtor(true, "Mock" ~ in_c.name().str)[$.end = " {}" ~ newline];
 
     foreach (m; in_c.methodRange()) {
         // dfmt off

--- a/test/testdata/cpp/dev/class_const_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_const_gmock.hpp.ref
@@ -6,6 +6,8 @@
 namespace TestDouble {
 class MockSimple : public Simple {
 public:
+    virtual ~MockSimple() {}
+
     MOCK_CONST_METHOD0(func1, void());
 };
 } //NS:TestDouble

--- a/test/testdata/cpp/dev/class_interface_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_interface_gmock.hpp.ref
@@ -6,6 +6,8 @@
 namespace TestDouble {
 class MockSimple : public Simple {
 public:
+    virtual ~MockSimple() {}
+
     MOCK_METHOD0(func1, int());
     MOCK_METHOD1(func2, void(int x));
     MOCK_METHOD1(func2, void(double x));

--- a/test/testdata/cpp/dev/class_interface_more_than_10_params_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_interface_more_than_10_params_gmock.hpp.ref
@@ -6,6 +6,8 @@
 namespace TestDouble {
 class MockSimple : public Simple {
 public:
+    virtual ~MockSimple() {}
+
     MOCK_METHOD10(func10, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
     MOCK_METHOD10(func11_part_1, void(int x1, int x2, int x3, int x4, int x5, int x6, int x7, int x8, int x9, int x10));
     MOCK_METHOD1(func11_part_2, int(int x11));

--- a/test/testdata/cpp/dev/class_multiple_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_multiple_gmock.hpp.ref
@@ -6,6 +6,8 @@
 namespace TestDouble {
 class MockGlobal1 : public Global1 {
 public:
+    virtual ~MockGlobal1() {}
+
     MOCK_CONST_METHOD0(func1, void());
 };
 } //NS:TestDouble
@@ -13,6 +15,8 @@ public:
 namespace TestDouble {
 class MockGlobal2 : public Global2 {
 public:
+    virtual ~MockGlobal2() {}
+
     MOCK_CONST_METHOD0(func1, void());
 };
 } //NS:TestDouble
@@ -20,6 +24,8 @@ public:
 namespace TestDouble {
 class MockGlobal3 : public Global3 {
 public:
+    virtual ~MockGlobal3() {}
+
     MOCK_METHOD0(func1, void());
 };
 } //NS:TestDouble
@@ -29,6 +35,8 @@ namespace ns2 {
 namespace TestDouble {
 class MockInsideNs2 : public InsideNs2 {
 public:
+    virtual ~MockInsideNs2() {}
+
     MOCK_CONST_METHOD0(func1, void());
 };
 } //NS:TestDouble
@@ -37,6 +45,8 @@ public:
 namespace TestDouble {
 class MockInsideNs1 : public InsideNs1 {
 public:
+    virtual ~MockInsideNs1() {}
+
     MOCK_CONST_METHOD0(func1, void());
 };
 } //NS:TestDouble

--- a/test/testdata/cpp/dev/class_variants_interface_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/class_variants_interface_gmock.hpp.ref
@@ -7,12 +7,16 @@ namespace no_inherit {
 namespace TestDouble {
 class MockVirtualWithDtor : public VirtualWithDtor {
 public:
+    virtual ~MockVirtualWithDtor() {}
+
 };
 } //NS:TestDouble
 
 namespace TestDouble {
 class MockCtorNotAffectingVirtualClassificationAsYes : public CtorNotAffectingVirtualClassificationAsYes {
 public:
+    virtual ~MockCtorNotAffectingVirtualClassificationAsYes() {}
+
     MOCK_METHOD0(foo, void());
 };
 } //NS:TestDouble
@@ -20,6 +24,8 @@ public:
 namespace TestDouble {
 class MockCtorNotAffectingVirtualClassificationAsPure : public CtorNotAffectingVirtualClassificationAsPure {
 public:
+    virtual ~MockCtorNotAffectingVirtualClassificationAsPure() {}
+
     MOCK_METHOD0(foo, void());
 };
 } //NS:TestDouble
@@ -27,6 +33,8 @@ public:
 namespace TestDouble {
 class MockCommonPatternForPureInterface1 : public CommonPatternForPureInterface1 {
 public:
+    virtual ~MockCommonPatternForPureInterface1() {}
+
     MOCK_METHOD0(expect_func_to_be_mocked, void());
 };
 } //NS:TestDouble
@@ -34,6 +42,8 @@ public:
 namespace TestDouble {
 class MockCommonPatternForPureInterface2 : public CommonPatternForPureInterface2 {
 public:
+    virtual ~MockCommonPatternForPureInterface2() {}
+
     MOCK_METHOD0(expect_func_to_be_mocked, void());
 };
 } //NS:TestDouble
@@ -41,6 +51,8 @@ public:
 namespace TestDouble {
 class MockAllProtPrivMadePublic : public AllProtPrivMadePublic {
 public:
+    virtual ~MockAllProtPrivMadePublic() {}
+
     MOCK_METHOD0(a_protected, void());
     MOCK_METHOD0(a_private, void());
 };
@@ -51,6 +63,8 @@ namespace inherit {
 namespace TestDouble {
 class MockDerivedVirtual : public DerivedVirtual {
 public:
+    virtual ~MockDerivedVirtual() {}
+
     MOCK_METHOD0(derived_func, void());
 };
 } //NS:TestDouble

--- a/test/testdata/cpp/dev/functions_gmock.hpp.ref
+++ b/test/testdata/cpp/dev/functions_gmock.hpp.ref
@@ -7,6 +7,8 @@ namespace ns {
 namespace TestDouble {
 class MockI_TestDouble : public I_TestDouble {
 public:
+    virtual ~MockI_TestDouble() {}
+
     MOCK_METHOD0(func_void, void());
     MOCK_METHOD0(func_return, int());
     MOCK_METHOD1(func_one_named, int(int a));

--- a/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
@@ -6,6 +6,8 @@
 namespace TestDouble {
 class MockI_TestDouble : public I_TestDouble {
 public:
+    virtual ~MockI_TestDouble() {}
+
     MOCK_METHOD1(tiger, unsigned char(const unsigned int x0));
     MOCK_METHOD1(cyber, unsigned char(const unsigned int x0));
     MOCK_METHOD0(func_void, void());


### PR DESCRIPTION
The C++ standard states that if a class with one or more virtual functions
but missing the virtual destructor is deleted it is undefined behavior.