### PR TITLE
test: detect compiler flags at runtime

### DIFF
--- a/test/cpp_tests.d
+++ b/test/cpp_tests.d
@@ -13,6 +13,8 @@ void devTest() {
     auto root = Path("testdata/cpp/dev");
     auto files = dirEntries(root, "*.{hpp}", SpanMode.shallow);
 
+    const auto flags = compilerFlags();
+
     foreach (f; files) {
         auto input_ext = Path(f);
         scope (failure)
@@ -47,7 +49,6 @@ void devTest() {
                 GR(Path(input.toString ~ "_gmock.hpp.ref"), out_gmock));
 
         println(Color.yellow, "Compiling");
-        auto flags = ["-std=c++03", "-Wpedantic", "-Werror"];
         auto mainf = Path("testdata/cpp/main_dev.cpp").absolutePath;
         incls ~= "-I" ~ input_ext.dirName.toString;
         switch (input_ext.baseName.toString) {

--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -13,6 +13,8 @@ void stage1() {
     auto root = Path("testdata/cstub/stage_1");
     auto files = dirEntries(root, "*.{h,hpp}", SpanMode.shallow);
 
+    const auto flags = compilerFlags();
+
     foreach (f; files) {
         auto input_ext = Path(f);
         scope (failure)
@@ -52,7 +54,6 @@ void stage1() {
                     out_global), GR(Path(input.toString ~ "_gmock.hpp.ref"), out_gmock));
 
         println(Color.yellow, "Compiling");
-        auto flags = ["-std=c++03", "-Wpedantic", "-Werror"];
         auto incls = ["-I" ~ input_ext.dirName.absolutePath.toString];
         auto mainf = Path("testdata/cstub/main1.cpp").absolutePath;
         switch (input_ext.baseName.toString) {
@@ -63,10 +64,10 @@ void stage1() {
             compileResult(out_impl, mainf, flags ~ ["-DTEST_INCLUDE", "-DTEST_FUNC_PTR"], incls);
             break;
         case "param_main.h":
-            compileResult(out_impl, mainf, flags, incls);
+            compileResult(out_impl, mainf, flags.dup, incls);
             break;
         case "variables.h":
-            compileResult(out_impl, mainf, flags, incls);
+            compileResult(out_impl, mainf, flags.dup, incls);
             break;
         case "const.h":
             compileResult(out_impl, mainf, flags ~ ["-DTEST_INCLUDE", "-DTEST_CONST"], incls);
@@ -92,6 +93,8 @@ void stage2() {
 
     auto root = Path("testdata/cstub/stage_2");
     auto files = dirEntries(root, "*.{h,hpp}", SpanMode.shallow);
+
+    const auto flags = compilerFlags();
 
     foreach (f; files) {
         auto input_ext = Path(f);
@@ -170,7 +173,6 @@ void stage2() {
         }
 
         println(Color.yellow, "Compiling");
-        auto flags = ["-std=c++03", "-Wpedantic", "-Werror"];
         auto mainf = Path("testdata/cstub/main1.cpp");
         incls ~= "-I" ~ input_ext.dirName.toString;
         switch (input_ext.baseName.toString) {

--- a/test/utils.d
+++ b/test/utils.d
@@ -236,3 +236,30 @@ void demangleProfileLog(Path out_fname) {
 
     run(args.data);
 }
+
+auto compilerFlags() {
+    .scriptlikeEcho = true;
+    scope (exit)
+        .scriptlikeEcho = false;
+
+    auto default_flags = ["-std=c++98"];
+    Args cmd;
+    cmd ~= "g++";
+    cmd ~= "-dumpversion";
+
+    auto r = tryRunCollect(cmd.data);
+    auto version_ = r.output;
+    writeln("Compiler version: ", version_);
+
+    if (r.status != 0) {
+        return default_flags;
+    }
+
+    if (version_.length == 0) {
+        return default_flags;
+    } else if (version_[0] == '5') {
+        return default_flags ~ ["-Wpedantic", "-Werror"];
+    } else {
+        return default_flags ~ ["-pedantic", "-Werror"];
+    }
+}


### PR DESCRIPTION
-Wpedantic is especially problematic. It is called -pedantic in older
compilers.