### PR TITLE
bug: differences in provided stdlibs result in failing

### DIFF
--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -58,7 +58,7 @@ void stage1() {
         auto mainf = Path("testdata/cstub/main1.cpp").absolutePath;
         switch (input_ext.baseName.toString) {
         case "bug_wchar.h":
-        case "test_include_stdlib.h":
+        case "test_include_stdlibs.h":
             // skip compiling, stdarg.h etc do not exist on all platforms
             break;
         case "param_gmock.h":


### PR DESCRIPTION
on some platforms.
It isn't important to try and compile so skip it.
The test is just to ensure that -nostdinc doesn't really remove them,
the builtin libs are used.