### PR TITLE
test: raise condition when configuring scriptlike yap

### DIFF
--- a/test/cpp_tests.d
+++ b/test/cpp_tests.d
@@ -59,11 +59,11 @@ TestParams genTestParams(string f, const ref TestEnv testEnv) {
 }
 
 void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
-    testEnv.echo("Input:%s", p.input_ext.toRawString);
+    dextoolYap("Input:%s", p.input_ext.toRawString);
     runDextool(p.input_ext, testEnv, p.dexParams, p.dexFlags);
 
     if (!p.skipCompare) {
-        testEnv.echo("Comparing");
+        dextoolYap("Comparing");
         auto input = p.input_ext.stripExtension;
         // dfmt off
         compareResult(
@@ -75,7 +75,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
     }
 
     if (!p.skipCompile) {
-        testEnv.echo("Compiling");
+        dextoolYap("Compiling");
         compileResult(p.out_impl, p.mainf, testEnv, p.compileFlags, p.compileIncls);
     }
 }
@@ -85,7 +85,7 @@ unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/bug_anon_namespace.hpp", testEnv);
 
-    testEnv.echo("Input:%s", p.input_ext.toRawString);
+    dextoolYap("Input:%s", p.input_ext.toRawString);
     runTestFile(p, testEnv);
 }
 

--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -59,11 +59,11 @@ TestParams genTestParams(string f, const ref TestEnv testEnv) {
 }
 
 void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
-    testEnv.echo("Input:%s", p.input_ext.toRawString);
+    dextoolYap("Input:%s", p.input_ext.toRawString);
     runDextool(p.input_ext, testEnv, p.dexParams, p.dexFlags);
 
     if (!p.skipCompare) {
-        testEnv.echo("Comparing");
+        dextoolYap("Comparing");
         auto input = p.input_ext.stripExtension;
         // dfmt off
         compareResult(
@@ -75,7 +75,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
     }
 
     if (!p.skipCompile) {
-        testEnv.echo("Compiling");
+        dextoolYap("Compiling");
         compileResult(p.out_impl, p.mainf, testEnv, p.compileFlags, p.compileIncls);
     }
 }
@@ -242,7 +242,7 @@ unittest {
     runTestFile(p, testEnv);
 
     // dfmt off
-    testEnv.echo("Comparing");
+    dextoolYap("Comparing");
     auto input = p.input_ext.stripExtension;
     compareResult(GR(input ~ Ext(".hpp.ref"), p.out_hdr),
                   GR(input ~ Ext(".cpp.ref"), p.out_impl),

--- a/test/external_tests.sh
+++ b/test/external_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 SCRIPT_DIR="$(dirname "$(dirname "$0")/$(readlink "$0")")"
 
-rdmd -g -unittest -I$SCRIPT_DIR/../unit-threaded/source -I$SCRIPT_DIR/scriptlike/src/ -of$SCRIPT_DIR/.external_tests $SCRIPT_DIR/external_main.d -s "$@"
+rdmd -g -unittest -I$SCRIPT_DIR/../unit-threaded/source -I$SCRIPT_DIR/scriptlike/src/ -of$SCRIPT_DIR/.external_tests $SCRIPT_DIR/external_main.d "$@"


### PR DESCRIPTION
By using the module constructor it is ensured that before anything is
ran the logging is configured.