### PR TITLE
bug: info.type isn't correctly set thus null string

### DIFF
--- a/plugin/backend/cvariant.d
+++ b/plugin/backend/cvariant.d
@@ -385,6 +385,8 @@ void generateCGlobalPreProcessorDefine(CxGlobalVariable g, string prefix, CppMod
     final switch (g.type.info.kind) with (TypeKind.Info) {
     case Kind.record:
         goto case;
+    case Kind.func:
+        goto case;
     case Kind.simple:
         ifndef.define(E(d_name) ~ E(g.name.str));
         break;
@@ -411,6 +413,8 @@ void generateCGlobalDefinition(CxGlobalVariable g, string prefix, CppModule code
     string txt;
     final switch (g.type.info.kind) with (TypeKind.Info) {
     case Kind.record:
+        goto case;
+    case Kind.func:
         goto case;
     case Kind.simple:
         txt = E(g.type.txt) ~ E(d_name);

--- a/plugin/backend/plantuml.d
+++ b/plugin/backend/plantuml.d
@@ -263,6 +263,8 @@ void generateClass(CppClass c, PlantumlModule m) {
                 uml.unsafeRelate(parent, tkv.type.info.type, Relate.Compose);
             }
             break;
+        case TypeKind.Info.Kind.func:
+            break;
         case Kind.array:
             break;
         case Kind.funcPtr:

--- a/source/cpptooling/analyzer/type.d
+++ b/source/cpptooling/analyzer/type.d
@@ -41,6 +41,13 @@ pure @safe nothrow @nogc struct TypeKind {
         string fmt;
     }
 
+    /** The type of a function prototype, 'void foo(int)'
+     * fmt = void %s(int)
+     */
+    static struct FuncInfo {
+        string fmt;
+    }
+
     /** Textual representation of simple types.
      *
      * The type 'const int x' would be:
@@ -69,6 +76,7 @@ pure @safe nothrow @nogc struct TypeKind {
         typeof(null) null_;
         SimpleInfo simple;
         ArrayInfo array;
+        FuncInfo func;
         FuncPtrInfo funcPtr;
         RecordInfo record;
     }
@@ -147,6 +155,9 @@ auto toString(TypeKind t, string id) {
         break;
     case Kind.array:
         txt = format(t.info.fmt, t.info.elementType, id, t.info.indexes);
+        break;
+    case Kind.func:
+        txt = format(t.info.fmt, id);
         break;
     case Kind.funcPtr:
         txt = format(t.info.fmt, id);

--- a/source/cpptooling/data/representation.d
+++ b/source/cpptooling/data/representation.d
@@ -327,9 +327,11 @@ const:
         auto app = appender!string();
         final switch (variable.type.info.kind) with (TypeKind.Info) {
         case Kind.record:
+            goto case;
+        case Kind.func:
+            goto case;
         case Kind.simple:
-            formattedWrite(app,
-                    variable.type.info.fmt, variable.name.str);
+            formattedWrite(app, variable.type.info.fmt, variable.name.str);
             break;
         case Kind.array:
             formattedWrite(app, variable.type.info.fmt,

--- a/test/testdata/cpp/dev/functions.hpp
+++ b/test/testdata/cpp/dev/functions.hpp
@@ -37,7 +37,7 @@ typedef struct Something_Big {
 extern void fun(func_ptr2 p, Something_Big b);
 
 // expect a correct call signature for a function ptr
-void func_ptr_arg(int (*a)(int p, int) , int b);
+void func_ptr_arg(int (*a)(int p, int), int b);
 
 // C++ behaves different from C.
 // In C++ the struct keyword is not expected to be kept in the function


### PR DESCRIPTION
Main problem is how function prototypes is handled.
Solved by separating those from other kinds.

Add contracts to ensure that info.type is never null in the future.