### PR TITLE
Reduce simple data coupling by using Flag instead of bool

### DIFF
--- a/plugin/backend/plantuml.d
+++ b/plugin/backend/plantuml.d
@@ -256,7 +256,7 @@ void generateClass(CppClass c, PlantumlModule m) {
             uml.unsafeRelate(parent, tkv.type.info.type, Relate.Aggregate);
             break;
         case Kind.simple:
-            if (tkv.type.isRecord && (tkv.type.isPointer || tkv.type.isRef)) {
+            if (tkv.type.isRecord && (tkv.type.isPtr || tkv.type.isRef)) {
                 uml.unsafeRelate(parent, tkv.type.info.type, Relate.Compose);
             }
             break;

--- a/source/cpptooling/analyzer/clang/utility.d
+++ b/source/cpptooling/analyzer/clang/utility.d
@@ -6,6 +6,7 @@ Author: Joakim Brännström (joakim.brannstrom@gmx.com)
 */
 module cpptooling.analyzer.clang.utility;
 
+import std.typecons : Flag, Yes, No;
 import logger = std.experimental.logger;
 
 import clang.Cursor;
@@ -107,7 +108,7 @@ auto extractParams(Cursor cursor, bool is_variadic) {
 
     if (is_variadic) {
         auto wtk = WrapTypeKind();
-        wtk.typeKind = makeTypeKind("", false, false, false);
+        wtk.typeKind = TypeKind.make("...");
         wtk.typeKind.info = TypeKind.SimpleInfo("%s");
         params ~= PTuple(wtk, "...");
     }

--- a/test/ut_main.d
+++ b/test/ut_main.d
@@ -8,6 +8,10 @@ import std.stdio;
 import unit_threaded.runner;
 
 int main(string[] args) {
+    //import unit_threaded : enableStackTrace;
+    //
+    //enableStackTrace();
+
     writeln(`Running unit tests`);
     //dfmt off
     return args.runTests!(


### PR DESCRIPTION
Ensure no leading whitespace of the type information by using contracts.