### PR TITLE
PlantUML plugin doesn't classify abstract classes

### DIFF
--- a/source/cpptooling/generator/adapter.d
+++ b/source/cpptooling/generator/adapter.d
@@ -36,7 +36,7 @@ CppClass makeAdapter(InterfaceT, KindT)(InterfaceT if_name) {
 
     c.put(CppCtor(CppMethodName(c_name), [param], CppAccess(AccessType.Public)));
     c.put(CppDtor(CppMethodName("~" ~ c_name), CppAccess(AccessType.Public),
-            CppVirtualMethod(VirtualType.No)));
+            CppVirtualMethod(MemberVirtualType.Normal)));
 
     return c;
 }

--- a/source/cpptooling/generator/classes.d
+++ b/source/cpptooling/generator/classes.d
@@ -31,12 +31,10 @@ void generateHdr(CppClass in_c, CppModule hdr) {
     }
 
     static void genMethod(CppMethod m, CppModule hdr) {
-        import cpptooling.data.representation : VirtualType;
-
         string params = m.paramRange().joinParams();
         auto o = hdr.method(m.isVirtual() ? Yes.isVirtual : No.isVirtual,
                 m.returnType().txt, m.name().str, m.isConst ? Yes.isConst : No.isConst, params);
-        if (m.virtualType() == VirtualType.Pure) {
+        if (m.isPure) {
             o[$.end = " = 0;"];
         }
     }

--- a/source/cpptooling/generator/func.d
+++ b/source/cpptooling/generator/func.d
@@ -81,7 +81,7 @@ CppClass makeFuncInterface(Tr)(Tr r, in MainInterface main_if) {
 
         auto name = CppMethodName(f.name.str);
         auto m = CppMethod(name, params, f.returnType(), CppAccess(AccessType.Public),
-                CppConstMethod(false), CppVirtualMethod(VirtualType.Pure));
+                CppConstMethod(false), CppVirtualMethod(MemberVirtualType.Pure));
 
         c.put(m);
     }

--- a/source/cpptooling/generator/gmock.d
+++ b/source/cpptooling/generator/gmock.d
@@ -33,10 +33,7 @@ import cpptooling.data.representation : CppClass, CppNamespace;
  */
 void generateGmock(ParamT)(CppClass in_c, CppModule hdr, ParamT params)
 in {
-    import std.algorithm : among;
-    import cpptooling.data.representation : VirtualType;
-
-    assert(in_c.virtualType.among(VirtualType.Pure, VirtualType.Yes));
+    assert(in_c.isVirtual);
 }
 body {
     import std.ascii : newline;
@@ -64,7 +61,7 @@ body {
     }
 
     static void genOp(CppMethodOp m, CppModule hdr) {
-        import cpptooling.data.representation : VirtualType;
+        import cpptooling.data.representation : MemberVirtualType;
 
         static string translateOp(string op) {
             switch (op) {
@@ -237,7 +234,7 @@ auto makeGmock(ClassT)(CppClass c) {
 
         auto params = m_.paramRange.array();
         auto m = CppMethod(m_.name, params, m_.returnType, CppAccess(AccessType.Public),
-                CppConstMethod(m_.isConst), CppVirtualMethod(VirtualType.Pure));
+                CppConstMethod(m_.isConst), CppVirtualMethod(MemberVirtualType.Pure));
         return m;
     }
 

--- a/test/plantuml_tests.d
+++ b/test/plantuml_tests.d
@@ -137,6 +137,13 @@ unittest {
     runTestFile(p, testEnv);
 }
 
+@Name("Should be a class diagram with an abstract class")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto p = genTestClassParams("dev/abstract_interface.hpp", testEnv);
+    runTestFile(p, testEnv);
+}
+
 @Name("Should be a class diagram with a class in a namespace visualized with fully qualified name")
 unittest {
     mixin(EnvSetup(globalTestdir));

--- a/test/testdata/uml/dev/abstract_interface.hpp
+++ b/test/testdata/uml/dev/abstract_interface.hpp
@@ -1,0 +1,7 @@
+class Abstract {
+    ~Abstract();
+
+    void fun();
+    virtual void gun();
+    virtual void wun() = 0;
+};

--- a/test/testdata/uml/dev/abstract_interface.pu.ref
+++ b/test/testdata/uml/dev/abstract_interface.pu.ref
@@ -1,0 +1,3 @@
+@startuml
+    class "Abstract" << (A, Pink) >>
+@enduml


### PR DESCRIPTION
Separate the classification type used for methods and classes to allow
specialization of the type.