### PR TITLE
Typedef's of arrays are wrongly classified

### DIFF
--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -1313,6 +1313,14 @@ body {
         }
     }
 
+    auto handleArray(ref Nullable!TypeResult rval) {
+        // must check for array:nes before Typedef because of the case when it
+        // is an array of typedef's
+        if (c_type.isArray) {
+            rval = typeToArray(c, c_type, container, indent);
+        }
+    }
+
     auto fallback(ref Nullable!TypeResult rval) {
         rval = passType(c, c_type, container, indent);
     }
@@ -1324,7 +1332,14 @@ body {
     }
 
     Nullable!TypeResult rval;
-    foreach (f; [&handlePointer, &handleTypedef, &handleTypeWithDecl, &fallback]) {
+    foreach (idx, f; [&handlePointer, &handleArray, &handleTypedef,
+            &handleTypeWithDecl, &fallback]) {
+        debug {
+            import std.conv : to;
+            import cpptooling.utility.logger : trace;
+
+            trace(idx.to!string(), this_indent);
+        }
         f(rval);
         if (!rval.isNull) {
             break;
@@ -1456,6 +1471,11 @@ body {
         rval.extra = [func.primary] ~ func.extra;
     }
 
+    auto handleArray(ref Nullable!TypeResult rval) {
+        auto type = c.type;
+        logType(type, this_indent);
+    }
+
     auto underlying(ref Nullable!TypeResult rval) {
         auto underlying = c.typedefUnderlyingType;
         auto tref = passType(c, underlying, container, indent);
@@ -1475,7 +1495,7 @@ body {
 
     typeof(return) rval;
     foreach (idx, f; [&handleTypeRefToTypeDeclFuncProto, &handleTyperef,
-            &handleFuncProto, &handleDecl, &underlying, &fallback]) {
+            &handleFuncProto, &handleDecl, &handleArray, &underlying, &fallback]) {
         debug {
             import std.conv : to;
             import cpptooling.utility.logger : trace;

--- a/test/testdata/cstub/stage_1/arrays.h
+++ b/test/testdata/cstub/stage_1/arrays.h
@@ -13,4 +13,10 @@ extern char extern_incmpl[];
 extern const char* const extern_const_incmpl[];
 
 extern int* const expect_const_ptr_array[10];
+
+typedef unsigned int MyIntType;
+extern MyIntType extern_typedef_array[16];
+
+typedef unsigned int MyArrayType[16];
+extern MyArrayType extern_array;
 #endif // ARRAYS_H

--- a/test/testdata/cstub/stage_1/arrays_global.cpp.ref
+++ b/test/testdata/cstub/stage_1/arrays_global.cpp.ref
@@ -6,6 +6,9 @@
 #ifndef TEST_INIT_extern_a
 #define TEST_INIT_extern_a int extern_a[4]
 #endif // TEST_INIT_extern_a
+#ifndef TEST_INIT_extern_array
+#define TEST_INIT_extern_array MyArrayType extern_array
+#endif // TEST_INIT_extern_array
 #ifndef TEST_INIT_extern_b
 #define TEST_INIT_extern_b int extern_b[2][3]
 #endif // TEST_INIT_extern_b
@@ -18,10 +21,15 @@
 #ifndef TEST_INIT_extern_incmpl
 #define TEST_INIT_extern_incmpl char extern_incmpl[]
 #endif // TEST_INIT_extern_incmpl
+#ifndef TEST_INIT_extern_typedef_array
+#define TEST_INIT_extern_typedef_array MyIntType extern_typedef_array[16]
+#endif // TEST_INIT_extern_typedef_array
 
 TEST_INIT_expect_const_ptr_array;
 TEST_INIT_extern_a;
+TEST_INIT_extern_array;
 TEST_INIT_extern_b;
 TEST_INIT_extern_c;
 TEST_INIT_extern_const_incmpl;
 TEST_INIT_extern_incmpl;
+TEST_INIT_extern_typedef_array;

--- a/test/testdata/cstub/stage_1/function_pointers.h
+++ b/test/testdata/cstub/stage_1/function_pointers.h
@@ -19,6 +19,7 @@ extern void (*const e_d)(void);
 extern int (*e_e)(int, int);
 extern int (*e_f)(int pa, int pb);
 extern int (*e_g)(int pa, int pb, ...);
+extern int (*e_array_func)(int x, int* y, int z[16]);
 
 /* subtle difference between a function prototype that is reused via a typedef
  * and a function pointer.
@@ -37,4 +38,7 @@ extern func_ptr hest;
 extern func_type tiger;
 extern func_param_type leopard;
 extern ref_param_type cyber;
+
+typedef int (array_func_type)(int* x, int z[16]);
+extern array_func_type typedef_array_func;
 #endif // FUNCTION_POINTERS_H

--- a/test/testdata/cstub/stage_1/function_pointers.hpp.ref
+++ b/test/testdata/cstub/stage_1/function_pointers.hpp.ref
@@ -9,6 +9,7 @@ class I_TestDouble {
 public:
     virtual func_type * cyber(const unsigned int baz) = 0;
     virtual func_type * leopard(const unsigned int baz) = 0;
+    virtual int typedef_array_func(int *x, int z[16]) = 0;
     virtual void tiger() = 0;
 };
 

--- a/test/testdata/cstub/stage_1/function_pointers_global.cpp.ref
+++ b/test/testdata/cstub/stage_1/function_pointers_global.cpp.ref
@@ -3,6 +3,9 @@
 #ifndef TEST_INIT_e_a
 #define TEST_INIT_e_a void (*e_a)()
 #endif // TEST_INIT_e_a
+#ifndef TEST_INIT_e_array_func
+#define TEST_INIT_e_array_func int (*e_array_func)(int x, int *y, int z[16])
+#endif // TEST_INIT_e_array_func
 #ifndef TEST_INIT_e_b
 #define TEST_INIT_e_b int (*e_b)()
 #endif // TEST_INIT_e_b
@@ -26,6 +29,7 @@
 #endif // TEST_INIT_hest
 
 TEST_INIT_e_a;
+TEST_INIT_e_array_func;
 TEST_INIT_e_b;
 TEST_INIT_e_c;
 TEST_INIT_e_d;

--- a/test/testdata/cstub/stage_1/functions.cpp.ref
+++ b/test/testdata/cstub/stage_1/functions.cpp.ref
@@ -40,6 +40,14 @@ int func_variadic_one_unnamed(char *x0, ...) {
     return test_double_inst->func_variadic_one_unnamed(x0);
 }
 
+void array_func(int x, int *y, int z[16]) {
+    test_double_inst->array_func(x, y, z);
+}
+
+void array_func_param_typedef(MyIntType x0[16]) {
+    test_double_inst->array_func_param_typedef(x0);
+}
+
 void c_func_three_named(const int a, const int b, const int c) {
     test_double_inst->c_func_three_named(a, b, c);
 }

--- a/test/testdata/cstub/stage_1/functions.h
+++ b/test/testdata/cstub/stage_1/functions.h
@@ -43,4 +43,10 @@ void c_func_with_struct(const struct A* a);
 
 // expecting static functions to be ignored
 static void ignore();
+
+// expecting the array parameter to be preserved
+void array_func(int x, int* y, int z[16]);
+
+typedef unsigned int MyIntType;
+void array_func_param_typedef(MyIntType [16]);
 #endif // FUNCTIONS_H

--- a/test/testdata/cstub/stage_1/functions.hpp.ref
+++ b/test/testdata/cstub/stage_1/functions.hpp.ref
@@ -13,6 +13,8 @@ public:
     virtual int func_one_named(int a) = 0;
     virtual int func_return() = 0;
     virtual int func_variadic_one_unnamed(char *x0) = 0;
+    virtual void array_func(int x, int *y, int z[16]) = 0;
+    virtual void array_func_param_typedef(MyIntType x0[16]) = 0;
     virtual void c_func_three_named(const int a, const int b, const int c) = 0;
     virtual void c_func_two_named(const int a, const int b) = 0;
     virtual void c_func_with_struct(const struct A *a) = 0;

--- a/test/testdata/cstub/stage_1/param_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock.hpp.ref
@@ -15,6 +15,9 @@ public:
     virtual int func_one_named(int a) = 0;
     virtual int func_return() = 0;
     virtual int func_variadic_one_unnamed(char *x0) = 0;
+    virtual int typedef_array_func(int *x, int z[16]) = 0;
+    virtual void array_func(int x, int *y, int z[16]) = 0;
+    virtual void array_func_param_typedef(MyIntType x0[16]) = 0;
     virtual void c_func_three_named(const int a, const int b, const int c) = 0;
     virtual void c_func_two_named(const int a, const int b) = 0;
     virtual void c_func_with_struct(const struct A *a) = 0;

--- a/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
@@ -16,6 +16,9 @@ public:
     MOCK_METHOD1(func_one_named, int(int a));
     MOCK_METHOD0(func_return, int());
     MOCK_METHOD1(func_variadic_one_unnamed, int(char *x0));
+    MOCK_METHOD2(typedef_array_func, int(int *x, int z[16]));
+    MOCK_METHOD3(array_func, void(int x, int *y, int z[16]));
+    MOCK_METHOD1(array_func_param_typedef, void(MyIntType x0[16]));
     MOCK_METHOD3(c_func_three_named, void(const int a, const int b, const int c));
     MOCK_METHOD2(c_func_two_named, void(const int a, const int b));
     MOCK_METHOD1(c_func_with_struct, void(const struct A *a));


### PR DESCRIPTION
Results in declarations missing the suffix "[<optional>]".

The tests for passing arrays of primitive types do not trigger the bug.
They are added for completeness.