### PR TITLE
Support searching for a relative or absolute path in CompilationDatabase

### DIFF
--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -1476,11 +1476,6 @@ body {
         rval.extra = [func.primary] ~ func.extra;
     }
 
-    auto handleArray(ref Nullable!TypeResult rval) {
-        auto type = c.type;
-        logType(type, this_indent);
-    }
-
     auto underlying(ref Nullable!TypeResult rval) {
         auto underlying = c.typedefUnderlyingType;
         auto tref = passType(c, underlying, container, indent);
@@ -1500,7 +1495,7 @@ body {
 
     typeof(return) rval;
     foreach (idx, f; [&handleTypeRefToTypeDeclFuncProto, &handleTyperef,
-            &handleFuncProto, &handleDecl, &handleArray, &underlying, &fallback]) {
+            &handleFuncProto, &handleDecl, &underlying, &fallback]) {
         debug {
             import std.conv : to;
             import cpptooling.utility.logger : trace;

--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -262,6 +262,22 @@ unittest {
     p.skipCompile = Yes.skipCompile;
     runTestFile(p, testEnv);
 }
+
+@Name(testId ~ "Should use the exact supplied --in=... as key when looking in compile db")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    TestParams p;
+    p.root = Path("testdata/compile_db").absolutePath;
+    p.input_ext = p.root ~ Path("file2.h");
+    p.out_hdr = testEnv.outdir ~ "test_double.hpp";
+
+    p.dexParams = ["ctestdouble", "--debug",
+        "--compile-db=" ~ (p.root ~ "db2.json").toString, "--in=file2.h"];
+
+    p.skipCompile = Yes.skipCompile;
+    p.skipCompare = Yes.skipCompare;
+    runTestFile(p, testEnv);
+}
 // END   Compilation Database Tests ##########################################
 
 // BEGIN CLI Tests ###########################################################
@@ -378,9 +394,8 @@ unittest {
     auto p = genTestParams("compile_db/param_many_in.h", testEnv);
 
     p.input_ext = Path("");
-    p.dexParams ~= ["--gmock", "--in=testdata/cstub/compile_db/dir1/file1.h",
-        "--in=testdata/cstub/compile_db/dir1/file2.h", "--compile-db",
-        (p.root ~ "compile_db/db.json").toString];
+    p.dexParams ~= ["--gmock", "--in=dir1/file1.h", "--in=dir1/file2.h",
+        "--compile-db", (p.root ~ "compile_db/db.json").toString];
     p.compileIncls.length = 0;
 
     p.skipCompile = Yes.skipCompile;


### PR DESCRIPTION
Allows the user to look in the DB for "file" and copy and paste
or autocomplete in the shell to the file.