### PR TITLE
refactor: improve maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dub.selections.json
 autobuild
 .autobuild.bin
 dscanner_report.txt
+docs.json

--- a/autobuild.d
+++ b/autobuild.d
@@ -558,9 +558,17 @@ struct Fsm {
         a ~= thisExePath.dirName ~ "build.sh";
         a ~= "build";
         a ~= ["-c", "debug"];
-        a ~= ["-b", "docs"];
 
-        tryRun(thisExePath.dirName, a.data);
+        auto ddox_a = a;
+        ddox_a ~= ["-b", "ddox"];
+
+        auto status = tryRun(thisExePath.dirName, ddox_a.data);
+        if (status != 0) {
+            // fallback to basic documentation generator
+            auto docs_a = a;
+            docs_a ~= ["-b", "docs"];
+            tryRun(thisExePath.dirName, docs_a.data);
+        }
     }
 
     void stateSlocs() {

--- a/dsrcgen/source/dsrcgen/c.d
+++ b/dsrcgen/source/dsrcgen/c.d
@@ -768,11 +768,6 @@ unittest {
         sep();
         comment("content comment");
     }
-    with (hdr.footer) {
-        text("footer text");
-        sep();
-        comment("footer comment");
-    }
 
     assert(hdr.render == "header text
 // header comment
@@ -781,8 +776,6 @@ unittest {
 content text
 // content comment
 #endif // somefile_hpp
-footer text
-// footer comment
 ", hdr.render);
 }
 

--- a/dsrcgen/source/dsrcgen/plantuml.d
+++ b/dsrcgen/source/dsrcgen/plantuml.d
@@ -305,6 +305,13 @@ auto method(T)(T m, string txt) if (CanHaveMethod!T) {
     return e;
 }
 
+///
+unittest {
+    auto m = new PlantumlModule;
+    auto class_ = m.classBody("A");
+    class_.method("void fun();");
+}
+
 auto method(T)(T m, Flag!"isVirtual" isVirtual, string return_type, string name,
         Flag!"isConst" isConst) if (CanHaveMethod!T) {
     import std.format : format;
@@ -345,10 +352,6 @@ auto ctorBody(T0, T...)(T0 m, string class_name, auto ref T args)
  *  m = ?
  *  isVirtual = if evaluated to true prepend with virtual.
  *  class_name = name of the class to create a d'tor for.
- * Example:
- * ----
- * dtor(Yes.isVirtual, "Foo");
- * ----
  */
 auto dtor(T)(T m, Flag!"isVirtual" isVirtual, string class_name)
         if (CanHaveMethod!T) {
@@ -357,6 +360,13 @@ auto dtor(T)(T m, Flag!"isVirtual" isVirtual, string class_name)
     auto e = m.getM.stmt(format("%s%s%s()", isVirtual ? "virtual " : "",
             class_name[0] == '~' ? "" : "~", class_name));
     return e;
+}
+
+///
+unittest {
+    auto m = new PlantumlModule;
+    auto class_ = m.classBody("Foo");
+    class_.dtor(Yes.isVirtual, "Foo");
 }
 
 auto dtor(T)(T m, string class_name) if (CanHaveMethod!T) {
@@ -368,12 +378,24 @@ auto dtor(T)(T m, string class_name) if (CanHaveMethod!T) {
 
 auto addSpot(T)(ref T m, string spot) if (is(T == ClassType)) {
     m.spot.clearChildren;
-
-    auto spot_ = m.as.text(" " ~ spot);
-    m.spot = spot_;
+    m.spot = m.as.text(" " ~ spot);
 
     return m.spot;
 }
+
+/// Creating a plantuml spot.
+/// Output:
+/// class A << I, #123456 >>
+///         '--the spot----'
+unittest {
+    auto m = new PlantumlModule;
+    auto class_ = m.class_("A");
+    class_.addSpot("<< I, #123456 >>");
+
+    m.render.shouldEqual(`    class "A" << I, #123456 >>
+`);
+}
+
 // End: Class Diagram functions
 
 // Begin: Component Diagram functions
@@ -387,10 +409,13 @@ auto addAs(T)(ref T m) if (is(T == ComponentType) || is(T == ClassType)) {
 }
 // End: Component Diagram functions
 
+/** Add a label to an existing relation.
+ *
+ * The meaning of LabelPos.
+ * A "Left" -- "Right" B : "OnRelation"
+ */
 auto label(Relation m, string txt, LabelPos pos) {
     import std.format : format;
-
-    // A "Left" -- "Right" B : "OnRelation"
 
     final switch (pos) with (LabelPos) {
     case Left:
@@ -406,6 +431,15 @@ auto label(Relation m, string txt, LabelPos pos) {
     }
 
     return m;
+}
+
+///
+unittest {
+    auto m = new PlantumlModule;
+    auto c0 = m.class_("A");
+    auto c1 = m.class_("B");
+    auto r0 = m.relate(c0.name, c1.name, Relate.Compose);
+    r0.label("foo", LabelPos.Right);
 }
 
 auto label(Relation m, string txt) {

--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -1143,7 +1143,7 @@ body {
     TypeResult return_rval;
 
     auto return_t = retrieveReturn(return_rval);
-    auto params = extractParams2(c, type, container, indent);
+    auto params = extractParams(c, type, container, indent);
     auto primary = makeTypeKindAttr(type);
 
     // a C++ member function must be queried for constness via a different API
@@ -1183,7 +1183,7 @@ body {
     import std.array;
 
     TypeResult rval;
-    auto params = extractParams2(c, type, container, indent);
+    auto params = extractParams(c, type, container, indent);
     auto primary = makeTypeKindAttr(type);
 
     TypeKind.CtorInfo info;
@@ -1794,10 +1794,10 @@ body {
     return rval;
 }
 
-private alias PTuple2 = Tuple!(TypeKindAttr, "tka", string, "id",
+private alias ExtractParamsResult = Tuple!(TypeKindAttr, "tka", string, "id",
         Flag!"isVariadic", "isVariadic");
 
-PTuple2[] extractParams2(ref const(Cursor) c, ref Type type,
+ExtractParamsResult[] extractParams(ref const(Cursor) c, ref Type type,
         ref const(Container) container, in uint this_indent)
 in {
     logNode(c, this_indent);
@@ -1814,7 +1814,7 @@ out (result) {
 body {
     auto indent = this_indent + 1;
 
-    void appendParams(ref const(Cursor) c, ref PTuple2[] params) {
+    void appendParams(ref const(Cursor) c, ref ExtractParamsResult[] params) {
         import std.range : enumerate;
 
         foreach (idx, p; c.children.enumerate) {
@@ -1825,7 +1825,7 @@ body {
 
             auto tka = retrieveType(p, container, indent);
             auto id = p.spelling;
-            params ~= PTuple2(tka.primary, id, No.isVariadic);
+            params ~= ExtractParamsResult(tka.primary, id, No.isVariadic);
         }
 
         if (type.func.isVariadic) {
@@ -1840,11 +1840,11 @@ body {
 
             // TODO remove this ugly hack
             // space as id to indicate it is empty
-            params ~= PTuple2(tka, " ", Yes.isVariadic);
+            params ~= ExtractParamsResult(tka, " ", Yes.isVariadic);
         }
     }
 
-    PTuple2[] params;
+    ExtractParamsResult[] params;
 
     if (c.kind == CXCursorKind.CXCursor_TypeRef) {
         auto cref = c.referenced;
@@ -1857,12 +1857,12 @@ body {
 }
 
 /// Join an array slice of PTuples to a parameter string of "type" "id"
-private string joinParamId(PTuple2[] r) {
+private string joinParamId(ExtractParamsResult[] r) {
     import std.algorithm : joiner, map, filter;
     import std.conv : text;
     import std.range : enumerate;
 
-    static string getTypeId(ref PTuple2 p, ulong uid) {
+    static string getTypeId(ref ExtractParamsResult p, ulong uid) {
         if (p.id.length == 0) {
             //TODO decide if to autogenerate for unnamed parameters here or later
             //return p.tka.toStringDecl("x" ~ text(uid));

--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -1794,34 +1794,6 @@ body {
     return rval;
 }
 
-//TODO handle anonymous namespace
-//TODO maybe merge with backtrackNode in clang/utility.d?
-private string[] backtrackScope(ref const(Cursor) c) {
-    import cpptooling.analyzer.clang.utility;
-
-    static struct GatherScope {
-        import std.array : Appender;
-
-        Appender!(string[]) app;
-
-        void apply(ref const(Cursor) c, int depth)
-        in {
-            logNode(c, depth);
-        }
-        body {
-            if (c.kind.among(CXCursorKind.CXCursor_UnionDecl, CXCursorKind.CXCursor_StructDecl,
-                    CXCursorKind.CXCursor_ClassDecl, CXCursorKind.CXCursor_Namespace)) {
-                app.put(c.spelling);
-            }
-        }
-    }
-
-    GatherScope gs;
-    backtrackNode(c, gs);
-
-    return gs.app.data;
-}
-
 private alias PTuple2 = Tuple!(TypeKindAttr, "tka", string, "id",
         Flag!"isVariadic", "isVariadic");
 

--- a/source/cpptooling/analyzer/clang/utility.d
+++ b/source/cpptooling/analyzer/clang/utility.d
@@ -22,68 +22,47 @@ version (unittest) {
     }
 }
 
-/** Travers a node tree and gather all paramdecl to an array.
- * Params:
- * cursor = A node containing ParmDecl nodes as children.
- * Example:
- * -----
- * class Simple{ Simple(char x, char y); }
- * -----
- * The AST for the above is kind of the following:
- * Example:
- * ---
- * Simple [CXCursor_Constructor Type(CXType(CXType_FunctionProto))
- *   x [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
- *   y [CXCursor_ParmDecl Type(CXType(CXType_Char_S))
- * ---
- * It is translated to the array [("char", "x"), ("char", "y")].
+//TODO handle anonymous namespace
+//TODO maybe merge with backtrackNode in clang/utility.d?
+/** Analyze the scope the declaration/definition reside in by backtracking to
+ * the root.
+ *
+ * TODO allow the caller to determine what cursor kind's are sent to the sink.
  */
-auto paramDeclTo(ref Cursor cursor, const ref Container container) {
-    import cpptooling.analyzer.clang.type;
-    import cpptooling.data.representation : TypeKindVariable, CppVariable,
-        makeCxParam, CxParam, VariadicType;
+void backtrackScope(NodeT, SinkT)(ref const(NodeT) node, scope SinkT sink) {
+    import std.algorithm : among;
+    import std.range.primitives : put;
 
-    CxParam[] rval;
+    import deimos.clang.index : CXCursorKind;
+    import cpptooling.analyzer.clang.type : logNode;
 
-    auto type = cursor.type;
-    auto params = extractParams2(cursor, type, container, 0);
-    foreach (p; params) {
-        rval ~= makeCxParam(TypeKindVariable(p.tka, CppVariable(p.id)));
+    static if (is(NodeT == Cursor)) {
+        Cursor curr = node;
+    } else {
+        // a Declaration class
+        // TODO add a constraint
+        Cursor curr = node.cursor;
     }
 
-    debug {
-        import std.variant : visit;
-
-        foreach (p; rval) {
-            // dfmt off
-            () @trusted {
-                p.visit!((TypeKindVariable p) => logger.trace(p.type.toStringDecl(cast(string) p.name)),
-                         (TypeKindAttr p) => logger.trace(p.toStringDecl("x")),
-                         (VariadicType p) => logger.trace("..."));
-            }();
-            // dfmt on
-        }
-    }
-
-    return params;
-}
-
-void backtrackNode(T)(ref const(Cursor) c, ref T callback, int depth = 0) {
-    import std.range : repeat;
-
-    Cursor curr = c;
+    int depth = 0;
     while (curr.isValid) {
-        callback.apply(curr, depth);
+        debug logNode(curr, depth);
+
+        if (curr.kind.among(CXCursorKind.CXCursor_UnionDecl, CXCursorKind.CXCursor_StructDecl,
+                CXCursorKind.CXCursor_ClassDecl, CXCursorKind.CXCursor_Namespace)) {
+            put(sink, curr.spelling);
+        }
+
         curr = curr.semanticParent;
         ++depth;
     }
 }
 
+//TODO remove the default value for indent.
 void put(ref Nullable!TypeResult tr, ref Container container, in uint indent = 0) @safe {
     import cpptooling.analyzer.clang.type : logTypeResult;
 
     if (!tr.isNull) {
-        logTypeResult(tr, indent);
         container.put(tr.primary.kind);
         foreach (e; tr.extra) {
             container.put(e.kind);

--- a/source/cpptooling/analyzer/kind.d
+++ b/source/cpptooling/analyzer/kind.d
@@ -22,11 +22,17 @@ alias FuncInfoParam = Tuple!(USRType, "usr", TypeAttr, "attr", string, "id",
         Flag!"isVariadic", "isVariadic");
 
 /// Convert an array of indexes to a string representation
-string toRepr(const(ArrayInfoIndex[]) index_nr) @safe pure {
+string toRepr(const(ArrayInfoIndex[]) indexes) @safe pure {
     import std.algorithm : map, joiner;
     import std.conv : text;
 
-    return index_nr.map!(a => a.isNull ? "[]" : "[" ~ text(a.get) ~ "]").joiner.text;
+    // dfmt off
+    return indexes
+        // a null is a dynamic index
+        .map!(a => a.isNull ? "[]" : "[" ~ text(a.get) ~ "]")
+        .joiner
+        .text;
+    // dfmt on
 }
 
 /** Type representation and information.

--- a/source/cpptooling/data/class_classification.d
+++ b/source/cpptooling/data/class_classification.d
@@ -73,7 +73,8 @@ body {
  *
  * Params:
  *  current = current state of the classification.
- *  data = indata to be used to determine next state
+ *  method_kind = indata, kind of method
+ *  method_virtual_type = indata, kind of "virtuality" the function is
  *  hasMember = a class with any members can at the most be virtual
  *
  * Returns: new classification state.

--- a/source/cpptooling/data/type.d
+++ b/source/cpptooling/data/type.d
@@ -119,6 +119,8 @@ struct Location {
  * Using a TaggedAlgebraic to allow adding more types in the future.
  */
 struct LocationTag {
+    import std.format : FormatSpec;
+
     enum Kind {
         noloc,
         loc
@@ -138,6 +140,35 @@ struct LocationTag {
         } else {
             this.kind = Kind.loc;
             this.payload = t;
+        }
+    }
+
+    string toString() @safe pure const {
+        import std.exception : assumeUnique;
+        import std.format : FormatSpec;
+
+        char[] buf;
+        buf.reserve(100);
+        auto fmt = FormatSpec!char("%s");
+        toString((const(char)[] s) { buf ~= s; }, fmt);
+        auto trustedUnique(T)(T t) @trusted {
+            return assumeUnique(t);
+        }
+
+        return trustedUnique(buf);
+    }
+
+    void toString(Writer, Char)(scope Writer w, FormatSpec!Char formatSpec) const {
+        import std.format : formatValue;
+        import std.range.primitives : put;
+
+        final switch (kind) {
+        case Kind.noloc:
+            put(w, "noloc");
+            break;
+        case Kind.loc:
+            put(w, this.payload.toString);
+            break;
         }
     }
 }


### PR DESCRIPTION
Fix documentation of public declarations.
Improve generated documentations usability by using ddox instead of the builtin docgen (ddoc).
Consolidate code that do basically the same thing (DRY).