### PR TITLE
Avoid the forced rebuild that preBuildCommands introduces for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ notifications:
 git:
     depth: 1
 
+branches:
+    only:
+        - master
+
 script: ./travis.sh
 after_success:
   # restrict what compiler coverage so it is possible to know what compiler

--- a/autobuild.d
+++ b/autobuild.d
@@ -394,6 +394,13 @@ struct Fsm {
 
         writeln("Watching the following paths for changes:");
         inotify_paths.each!writeln;
+
+        enum version_txt = "resources/version.txt";
+        if (!exists(version_txt)) {
+            auto f = File(version_txt, "w");
+            f.write("test");
+            writeln("Creating dummy resources/version.txt");
+        }
     }
 
     void stateAudioStatus() {

--- a/dub.sdl
+++ b/dub.sdl
@@ -33,8 +33,6 @@ sourcePaths "source" "plugin"
 importPaths "source" "plugin"
 stringImportPaths "resources"
 
-preBuildCommands "$ROOT_PACKAGE_DIR/gen_version_from_git.sh"
-
 // -rpath is relative path for all linked libraries. The second "." is argument to rpath.
 lflags "--enable-new-dtags" "-rpath=." "$LFLAG_CLANG_PATH"
 libs "$LFLAG_CLANG_LIB"
@@ -47,6 +45,8 @@ configuration "application" {
     targetName "dextool"
     targetType "executable"
 
+    preBuildCommands "$ROOT_PACKAGE_DIR/gen_version_from_git.sh"
+
     mainSourceFile "source/application/app.d"
     excludedSourceFiles "source/test/*" "source/devtool/*"
 }
@@ -54,6 +54,12 @@ configuration "application" {
 configuration "debug" {
     targetName "dextool-debug"
     targetType "executable"
+
+    // the preBuildCommands is NOT in this configuration because it forces a
+    // recompilation every time dub is ran even though. It slows down
+    // development time when updating tests.
+    // To build this configuration either run "./autobuild.sh --run_and_exit" or
+    // run "touch resources/version.txt && dub build -c debug"
 
     mainSourceFile "source/application/app.d"
     excludedSourceFiles "source/test/*" "source/devtool/*"


### PR DESCRIPTION
unrelated changes by moving it to inside a configuration.

In the same PR fixing interaction between Travis/CodeCov