### PR TITLE
Bugfix: function signature for a function returning a typedef:ed

### DIFF
--- a/test/testdata/cstub/stage_1/functions.cpp.ref
+++ b/test/testdata/cstub/stage_1/functions.cpp.ref
@@ -24,6 +24,10 @@ const int c_func_return() {
     return test_double_inst->c_func_return();
 }
 
+gun_ptr func_return_func_ptr() {
+    return test_double_inst->func_return_func_ptr();
+}
+
 int func_extern(int out) {
     return test_double_inst->func_extern(out);
 }
@@ -82,6 +86,10 @@ void func_variadic() {
 
 void func_void() {
     test_double_inst->func_void();
+}
+
+void gun_func(int x0) {
+    test_double_inst->gun_func(x0);
 }
 
 void unnamed_params(int x0, int x1) {

--- a/test/testdata/cstub/stage_1/functions.h
+++ b/test/testdata/cstub/stage_1/functions.h
@@ -37,6 +37,15 @@ extern void fun(func_ptr2 p, Something_Big b);
 // expect a correct call signature for a function ptr
 void func_ptr_arg(int (*a)(int p, int) , int b);
 
+// expect the exact signature below. Using a char* as a parameter to ensure the
+// generated test double when/if it doesn't work has a different signature.
+typedef void (gun_type)(int);
+typedef gun_type* gun_ptr;
+gun_ptr func_return_func_ptr();
+
+// using a typedef signature to create a function
+extern gun_type gun_func;
+
 // expect a func signature exactly as the function below.
 // Not uncommon in C code that the keyword struct is used.
 void c_func_with_struct(const struct A* a);
@@ -49,4 +58,5 @@ void array_func(int x, int* y, int z[16]);
 
 typedef unsigned int MyIntType;
 void array_func_param_typedef(MyIntType [16]);
+
 #endif // FUNCTIONS_H

--- a/test/testdata/cstub/stage_1/functions.hpp.ref
+++ b/test/testdata/cstub/stage_1/functions.hpp.ref
@@ -9,6 +9,7 @@ class I_TestDouble {
 public:
     virtual const int c_func_one_named(const int a) = 0;
     virtual const int c_func_return() = 0;
+    virtual gun_ptr func_return_func_ptr() = 0;
     virtual int func_extern(int out) = 0;
     virtual int func_one_named(int a) = 0;
     virtual int func_return() = 0;
@@ -24,6 +25,7 @@ public:
     virtual void func_two_named(int a, int b) = 0;
     virtual void func_variadic() = 0;
     virtual void func_void() = 0;
+    virtual void gun_func(int x0) = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
 };
 

--- a/test/testdata/cstub/stage_1/param_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock.hpp.ref
@@ -11,6 +11,7 @@ public:
     virtual const int c_func_return() = 0;
     virtual func_type * cyber(const unsigned int baz) = 0;
     virtual func_type * leopard(const unsigned int baz) = 0;
+    virtual gun_ptr func_return_func_ptr() = 0;
     virtual int func_extern(int out) = 0;
     virtual int func_one_named(int a) = 0;
     virtual int func_return() = 0;
@@ -27,6 +28,7 @@ public:
     virtual void func_two_named(int a, int b) = 0;
     virtual void func_variadic() = 0;
     virtual void func_void() = 0;
+    virtual void gun_func(int x0) = 0;
     virtual void tiger() = 0;
     virtual void unnamed_params(int x0, int x1) = 0;
 };

--- a/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
+++ b/test/testdata/cstub/stage_1/param_gmock_gmock.hpp.ref
@@ -12,6 +12,7 @@ public:
     MOCK_METHOD0(c_func_return, const int());
     MOCK_METHOD1(cyber, func_type *(const unsigned int baz));
     MOCK_METHOD1(leopard, func_type *(const unsigned int baz));
+    MOCK_METHOD0(func_return_func_ptr, gun_ptr());
     MOCK_METHOD1(func_extern, int(int out));
     MOCK_METHOD1(func_one_named, int(int a));
     MOCK_METHOD0(func_return, int());
@@ -28,6 +29,7 @@ public:
     MOCK_METHOD2(func_two_named, void(int a, int b));
     MOCK_METHOD0(func_variadic, void());
     MOCK_METHOD0(func_void, void());
+    MOCK_METHOD1(gun_func, void(int x0));
     MOCK_METHOD0(tiger, void());
     MOCK_METHOD2(unnamed_params, void(int x0, int x1));
 };


### PR DESCRIPTION
function ptr is derived from the return value.