### PR TITLE
Missing the concept of a function signature which is present in C/C++

### DIFF
--- a/plugin/backend/cvariant.d
+++ b/plugin/backend/cvariant.d
@@ -477,6 +477,7 @@ void generateCGlobalPreProcessorDefine(ref CxGlobalVariable global, string prefi
     case Kind.array:
     case Kind.func:
     case Kind.funcPtr:
+    case Kind.funcSignature:
     case Kind.pointer:
     case Kind.record:
     case Kind.simple:

--- a/plugin/backend/plantuml.d
+++ b/plugin/backend/plantuml.d
@@ -1998,6 +1998,7 @@ private auto resolveTypeRef(LookupT)(TypeKind type, LookupT lookup) {
     case Kind.ctor:
     case Kind.dtor:
     case Kind.func:
+    case Kind.funcSignature:
     case Kind.record:
     case Kind.simple:
         rval = only(cast(const TypeKind) type);
@@ -2082,6 +2083,7 @@ auto getClassMemberRelation(LookupT)(TypeKindAttr type, LookupT lookup) {
     case Kind.simple:
     case Kind.func:
     case Kind.funcPtr:
+    case Kind.funcSignature:
     case Kind.ctor:
     case Kind.dtor:
     case Kind.null_:
@@ -2128,6 +2130,7 @@ private ClassRelate getTypeRelation(LookupT)(TypeKindAttr tk, LookupT lookup) {
     case Kind.simple:
     case Kind.func:
     case Kind.funcPtr:
+    case Kind.funcSignature:
     case Kind.ctor:
     case Kind.dtor:
     case Kind.null_:

--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -1113,8 +1113,9 @@ body {
     return rval;
 }
 
-private TypeResults typeToFuncProto(ref const(Cursor) c, ref Type type,
-        ref const(Container) container, in uint indent)
+private TypeResults typeToFuncProto(InfoT = TypeKind.FuncInfo)(ref const(Cursor) c,
+        ref Type type, ref const(Container) container, in uint indent)
+        if (is(InfoT == TypeKind.FuncInfo) || is(InfoT == TypeKind.FuncSignatureInfo))
 in {
     logNode(c, indent);
     logType(type, indent);
@@ -1158,7 +1159,7 @@ body {
     // a C++ member function must be queried for constness via a different API
     primary.type.attr.isConst = cast(Flag!"isConst") c.func.isConst;
 
-    TypeKind.FuncInfo info;
+    InfoT info;
     info.fmt = format("%s %s(%s)", return_t.toStringDecl.strip, "%s", params.joinParamId());
     info.return_ = return_t.kind.usr;
     info.returnAttr = return_t.attr;
@@ -1623,11 +1624,7 @@ body {
         }
 
         auto type = c.type;
-        auto func = typeToFuncProto(c, type, container, indent);
-
-        // a USR for the function do not exist because the only sensible would
-        // be the typedef... but it is used by the typedef _for this function_
-        func.primary.type.kind.usr = makeFallbackUSR(c, indent);
+        auto func = typeToFuncProto!(TypeKind.FuncSignatureInfo)(c, type, container, indent);
 
         rval = typeToTypedef(c, type, func.primary.type.kind.usr,
                 func.primary.type.kind.usr, container, indent);
@@ -1721,17 +1718,34 @@ body {
         }
         auto retrieved_ref = retrieveType(child, container, indent);
 
-        if (!retrieved_ref.isNull
-                && retrieved_ref.primary.type.kind.info.kind == TypeKind.Info.Kind.func) {
+        if (retrieved_ref.isNull) {
+            continue;
+        }
+
+        if (retrieved_ref.primary.type.kind.info.kind == TypeKind.Info.Kind.func) {
             // fast path
             rval = retrieved_ref;
-        } else if (!retrieved_ref.isNull
-                && retrieved_ref.primary.type.kind.info.kind == TypeKind.Info.Kind.typeRef) {
+        } else if (retrieved_ref.primary.type.kind.info.kind == TypeKind.Info.Kind.typeRef) {
             // check the canonical type
             foreach (k; chain(only(retrieved_ref.primary), retrieved_ref.extra)) {
-                if (k.type.kind.usr == retrieved_ref.primary.type.kind.info.canonicalRef
-                        && k.type.kind.info.kind == TypeKind.Info.Kind.func) {
+                if (k.type.kind.usr != retrieved_ref.primary.type.kind.info.canonicalRef) {
+                    continue;
+                }
+
+                if (k.type.kind.info.kind == TypeKind.Info.Kind.func) {
                     rval = retrieved_ref;
+                } else if (k.type.kind.info.kind == TypeKind.Info.Kind.funcSignature) {
+                    // function declaration of a typedef'ed signature
+                    rval = retrieved_ref;
+                    rval.extra ~= rval.primary;
+
+                    auto prim = k;
+                    auto info = k.type.kind.info;
+                    prim.type.kind.info = TypeKind.FuncInfo(info.fmt,
+                            info.return_, info.returnAttr, info.params);
+                    prim.location = makeLocation(c);
+                    prim.type.kind.usr = makeFallbackUSR(c, this_indent);
+                    rval.primary = prim;
                 }
             }
         }

--- a/source/cpptooling/analyzer/kind.d
+++ b/source/cpptooling/analyzer/kind.d
@@ -68,7 +68,7 @@ pure @safe nothrow @nogc struct TypeKind {
         TypeAttr elementAttr;
     }
 
-    /** The type 'extern int (*e_g)(int pa)'
+    /** The type 'extern int (*e_g)(int pa)'.
      *
      * attrs is only for the pointers, never the final pointee.
      * In the example shown about it would have length 2.
@@ -88,7 +88,30 @@ pure @safe nothrow @nogc struct TypeKind {
         TypeAttr[] attrs;
     }
 
-    /** The type of a function prototype, 'void foo(int)'
+    /** The type of a function signature, 'void foo(int)'.
+     *
+     * fmt = void %s(int)
+     */
+    static struct FuncSignatureInfo {
+        string fmt;
+        USRType return_;
+        TypeAttr returnAttr;
+        FuncInfoParam[] params;
+    }
+
+    /** The type of a function prototype, 'void foo(int)'.
+     *
+     * TODO consider changing the chain to be a FuncInfo referencing a FuncSignatureInfo.
+     *
+     * This coupled with FuncSignatureInfo having the USR of the signature
+     * would mean that it would be possible to merge/detect/find all those
+     * FuncInfo with the same symbol mangling/signature.
+     *
+     * Which is needed when doing cross-translation unit analyse to find
+     * connections between "points of interest.
+     *
+     * It would also lower the amount of data in a FuncInfo.
+     *
      * fmt = void %s(int)
      */
     static struct FuncInfo {
@@ -173,8 +196,11 @@ pure @safe nothrow @nogc struct TypeKind {
         typeof(null) null_;
         SimpleInfo simple;
         ArrayInfo array;
+
         FuncInfo func;
         FuncPtrInfo funcPtr;
+        FuncSignatureInfo funcSignature;
+
         RecordInfo record;
         CtorInfo ctor;
         DtorInfo dtor;
@@ -208,6 +234,9 @@ pure @safe nothrow @nogc struct TypeKind {
             assert(info.fmt.length > 0);
             assert(info.attrs.length > 0);
             break;
+        case Kind.funcSignature:
+            assert(info.fmt.length > 0);
+            break;
         case Kind.pointer:
             assert(info.fmt.length > 0);
             assert(info.attrs.length > 0);
@@ -239,6 +268,7 @@ auto internalGetFmt(ref const TypeKind t) {
     case Kind.array:
     case Kind.func:
     case Kind.funcPtr:
+    case Kind.funcSignature:
     case Kind.record:
     case Kind.pointer:
     case Kind.ctor:

--- a/source/cpptooling/analyzer/type.d
+++ b/source/cpptooling/analyzer/type.d
@@ -166,6 +166,7 @@ auto toStringDecl(const TypeKind t, const TypeAttr ta, string id) {
         txt.put(t.info.elementAttr.isConst ? "const " : "");
         txt.formattedWrite(t.info.fmt, id, t.info.indexes.toRepr);
         break;
+    case Kind.funcSignature:
     case Kind.func:
         txt.formattedWrite(t.info.fmt, id);
         txt.put(ta.isConst ? " const" : "");

--- a/source/cpptooling/data/representation.d
+++ b/source/cpptooling/data/representation.d
@@ -355,12 +355,12 @@ const:
         case Kind.record:
         case Kind.func:
         case Kind.funcPtr:
+        case Kind.funcSignature:
         case Kind.simple:
         case Kind.typeRef:
         case Kind.array:
         case Kind.pointer:
-            formattedWrite(sink,
-                    "%s;", variable.type.toStringDecl(variable.name.str));
+            formattedWrite(sink, "%s;", variable.type.toStringDecl(variable.name.str));
             if (!usr.isNull) {
                 put(sink, " // ");
                 put(sink, cast(string) usr);

--- a/test/testdata/cstub/stage_1/functions.h
+++ b/test/testdata/cstub/stage_1/functions.h
@@ -37,8 +37,8 @@ extern void fun(func_ptr2 p, Something_Big b);
 // expect a correct call signature for a function ptr
 void func_ptr_arg(int (*a)(int p, int) , int b);
 
-// expect the exact signature below. Using a char* as a parameter to ensure the
-// generated test double when/if it doesn't work has a different signature.
+// expecting a func_return_func_ptr in the generated test double.
+// (bug) Previously it derived the function signature from the return value.
 typedef void (gun_type)(int);
 typedef gun_type* gun_ptr;
 gun_ptr func_return_func_ptr();


### PR DESCRIPTION
via typedef:s.

Fixes a bug where the location, which is crucial it is correct when
filtering symbols, is from where the function is declared and not the
typedef signatures location.