### PR TITLE
Current implementation of type deduction result in the definition of a

### DIFF
--- a/source/cpptooling/data/symbol/container.d
+++ b/source/cpptooling/data/symbol/container.d
@@ -346,7 +346,8 @@ struct Container {
 
         if (is_definition) {
             if (decl.hasDefinition) {
-                logger.errorf("Multiple definitions of %s (%s)", cast(string) usr, location);
+                debug logger.tracef("Definition already in container, %s (%s)",
+                        cast(string) usr, location);
             } else {
                 decl.definition = location;
             }


### PR DESCRIPTION
symbol being found multiple times.

It is not an error, therefore changing to a trace.
It should be used as an optimization opportunity.