### PR TITLE
Paths from a compilation DB are incorrectly computed

### DIFF
--- a/test/testdata/compile_db/db1.json
+++ b/test/testdata/compile_db/db1.json
@@ -1,11 +1,11 @@
 [
     {
-        "directory": "testdata/compile_db",
+        "directory": ".",
         "command": "g++ -I. -c -o binary file1.h",
         "file": "file1.h"
     },
     {
-        "directory": "testdata/compile_db",
+        "directory": ".",
         "command": "g++ -I. -c -o binary file1.hpp",
         "file": "file1.hpp"
     }

--- a/test/testdata/compile_db/db2.json
+++ b/test/testdata/compile_db/db2.json
@@ -1,16 +1,16 @@
 [
     {
-        "directory": "testdata/compile_db",
+        "directory": ".",
         "command": "g++ -I. -c -o binary file2.h",
         "file": "file2.h"
     },
     {
-        "directory": "testdata/compile_db",
+        "directory": ".",
         "command": "g++ -I. -c -o binary file2.hpp",
         "file": "file2.hpp"
     },
     {
-        "directory": "testdata/compile_db",
+        "directory": ".",
         "command": "g++ -I. -c -o binary file2.cpp",
         "file": "2.cpp"
     }

--- a/test/testdata/cpp/compile_db/single_file_db.json
+++ b/test/testdata/cpp/compile_db/single_file_db.json
@@ -1,6 +1,6 @@
 [
     {
-        "directory": "testdata/cpp/compile_db",
+        "directory": ".",
         "command": "g++ -Idir1 -c -o binary single_file_main.c",
         "file": "single_file_main.hpp"
     }

--- a/test/testdata/cstub/compile_db/db.json
+++ b/test/testdata/cstub/compile_db/db.json
@@ -1,11 +1,11 @@
 [
     {
-        "directory": "testdata/cstub/compile_db",
+        "directory": ".",
         "command": "gcc -Idir1 -c -o binary file1.h",
         "file": "dir1/file1.h"
     },
     {
-        "directory": "testdata/cstub/compile_db",
+        "directory": ".",
         "command": "gcc -Idir1 -c -o binary file2.h",
         "file": "dir1/file2.h"
     }

--- a/test/testdata/cstub/compile_db/single_file_db.json
+++ b/test/testdata/cstub/compile_db/single_file_db.json
@@ -1,6 +1,6 @@
 [
     {
-        "directory": "testdata/cstub/compile_db",
+        "directory": ".",
         "command": "g++ -Idir1 -c -o binary single_file_main.c",
         "file": "single_file_main.c"
     }

--- a/test/testdata/uml/compile_db/bad_code_db.json
+++ b/test/testdata/uml/compile_db/bad_code_db.json
@@ -1,11 +1,11 @@
 [
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -I bad_code -c -o binary dir3/f1.hpp",
         "file": "bad_code/f1.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -I bad_code -c -o binary dir3/f2.hpp",
         "file": "bad_code/f2.hpp"
     }

--- a/test/testdata/uml/compile_db/merge_nested_ns_db.json
+++ b/test/testdata/uml/compile_db/merge_nested_ns_db.json
@@ -1,41 +1,41 @@
 [
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/file1.hpp",
         "file": "dir3/file1.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/file2.hpp",
         "file": "dir3/file2.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/class_ns.hpp",
         "file": "dir3/class_ns.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/nested_c.hpp",
         "file": "dir3/nested_c.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/nested_d.hpp",
         "file": "dir3/nested_d.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/nested_e.hpp",
         "file": "dir3/nested_e.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/dup_class1.hpp",
         "file": "dir3/dup_class1.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/dup_class2.hpp",
         "file": "dir3/dup_class2.hpp"
     }

--- a/test/testdata/uml/compile_db/multi_file_db.json
+++ b/test/testdata/uml/compile_db/multi_file_db.json
@@ -1,16 +1,16 @@
 [
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir1 -c -o binary dir1/track_by_rval_ptr_ref.hpp",
         "file": "dir1/track_by_rval_ptr_ref.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir2 -c -o binary dir2/track_ptr.hpp",
         "file": "dir2/track_ptr.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir3 -c -o binary dir3/track_ref.hpp",
         "file": "dir3/track_ref.hpp"
     }

--- a/test/testdata/uml/compile_db/single_file_db.json
+++ b/test/testdata/uml/compile_db/single_file_db.json
@@ -1,6 +1,6 @@
 [
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir1 -c -o binary single_file_main.c",
         "file": "single_file_main.hpp"
     }

--- a/test/testdata/uml/compile_db/two_file_db.json
+++ b/test/testdata/uml/compile_db/two_file_db.json
@@ -1,11 +1,11 @@
 [
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir2 -c -o binary dir2/file1.hpp",
         "file": "dir2/file1.hpp"
     },
     {
-        "directory": "testdata/uml/compile_db",
+        "directory": ".",
         "command": "g++ -Idir2 -c -o binary dir2/file2.hpp",
         "file": "dir2/file2.hpp"
     }


### PR DESCRIPTION
The computation must take into consideration the compilation database
files location.