### PR TITLE
test: hard to compare the diff when it is sorted

### DIFF
--- a/test/cpp_tests.d
+++ b/test/cpp_tests.d
@@ -58,7 +58,8 @@ TestParams genTestParams(string f, const ref TestEnv testEnv) {
     return p;
 }
 
-void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
+void runTestFile(const ref TestParams p, ref TestEnv testEnv,
+        Flag!"sortLines" sortLines = No.sortLines) {
     dextoolYap("Input:%s", p.input_ext.toRawString);
     runDextool(p.input_ext, testEnv, p.dexParams, p.dexFlags);
 
@@ -66,7 +67,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
         dextoolYap("Comparing");
         auto input = p.input_ext.stripExtension;
         // dfmt off
-        compareResult(
+        compareResult(sortLines,
                       GR(input ~ Ext(".hpp.ref"), p.out_hdr),
                       GR(input ~ Ext(".cpp.ref"), p.out_impl),
                       GR(Path(input.toString ~ "_global.cpp.ref"), p.out_global),
@@ -76,7 +77,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
 
     if (!p.skipCompile) {
         dextoolYap("Compiling");
-        compileResult(p.out_impl, p.mainf, testEnv, p.compileFlags, p.compileIncls);
+        compileResult(p.out_impl, p.mainf, testEnv, sortLines, p.compileFlags, p.compileIncls);
     }
 }
 

--- a/test/cstub_tests.d
+++ b/test/cstub_tests.d
@@ -69,7 +69,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
         dextoolYap("Comparing");
         Path base = p.base_cmp;
         // dfmt off
-        compareResult(
+        compareResult(No.sortLines,
                       GR(base ~ Ext(".hpp.ref"), p.out_hdr),
                       GR(base ~ Ext(".cpp.ref"), p.out_impl),
                       GR(Path(base.toString ~ "_global.cpp.ref"), p.out_global),
@@ -79,7 +79,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
 
     if (!p.skipCompile) {
         dextoolYap("Compiling");
-        compileResult(p.out_impl, p.mainf, testEnv, p.compileFlags, p.compileIncls);
+        compileResult(p.out_impl, p.mainf, testEnv, No.sortLines, p.compileFlags, p.compileIncls);
     }
 }
 
@@ -333,7 +333,8 @@ unittest {
     // dfmt off
     dextoolYap("Comparing");
     auto input = p.input_ext.stripExtension;
-    compareResult(GR(input ~ Ext(".hpp.ref"), p.out_hdr),
+    compareResult(No.sortLines,
+                  GR(input ~ Ext(".hpp.ref"), p.out_hdr),
                   GR(input ~ Ext(".cpp.ref"), p.out_impl),
                   GR(input.up ~ "param_gen_pre_includes.hpp.ref", testEnv.outdir ~ "test_double_pre_includes.hpp"),
                   GR(input.up ~ "param_gen_post_includes.hpp.ref", testEnv.outdir ~ "test_double_post_includes.hpp"));

--- a/test/plantuml_tests.d
+++ b/test/plantuml_tests.d
@@ -62,7 +62,8 @@ TestParams genTestComponentParams(string f, const ref TestEnv testEnv) {
     return p;
 }
 
-void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
+void runTestFile(const ref TestParams p, ref TestEnv testEnv,
+        Flag!"sortLines" sortLines = Yes.sortLines) {
     dextoolYap("Input:%s", p.input_ext.toRawString);
     runDextool(p.input_ext, testEnv, p.dexParams ~ p.dexDiagramParams, p.dexFlags);
 
@@ -70,7 +71,7 @@ void runTestFile(const ref TestParams p, ref TestEnv testEnv) {
         dextoolYap("Comparing");
         Path input = p.base_file_compare;
         // dfmt off
-        compareResult(
+        compareResult(sortLines,
                       GR(input ~ Ext(".pu.ref"), p.out_pu),
                       );
         // dfmt on
@@ -328,7 +329,7 @@ unittest {
     import std.file : exists;
 
     exists((testEnv.outdir ~ "view_style.iuml").toString).shouldBeTrue;
-    compareResult(GR(Path(p.base_file_compare.toString ~ "_style.pu.ref"),
+    compareResult(Yes.sortLines, GR(Path(p.base_file_compare.toString ~ "_style.pu.ref"),
             testEnv.outdir ~ "view_style.iuml"));
 }
 

--- a/test/utils.d
+++ b/test/utils.d
@@ -168,7 +168,7 @@ struct GR {
  * The purpose is to limit the amount of text that is dumped.
  * The reasoning is that it is better to give more than one line as feedback.
  */
-void compare(in Path gold, in Path result, Flag!"sortLines" sortLines = Yes.sortLines) {
+void compare(in Path gold, in Path result, Flag!"sortLines" sortLines) {
     import std.algorithm : joiner, map;
     import std.stdio : File;
     import std.utf : toUTF8;
@@ -362,18 +362,18 @@ auto runDextool(T)(in T input, const ref TestEnv testEnv, in string[] pre_args, 
     return sw.peek.msecs;
 }
 
-void compareResult(T...)(in T args) {
+void compareResult(T...)(Flag!"sortLines" sortLines, in T args) {
     static assert(args.length >= 1);
 
     foreach (a; args) {
         if (existsAsFile(a.gold)) {
-            compare(a.gold, a.result);
+            compare(a.gold, a.result, sortLines);
         }
     }
 }
 
 void compileResult(in Path input, in Path main, const ref TestEnv testEnv,
-        in string[] flags, in string[] incls) {
+        Flag!"sortLines" sortLines, in string[] flags, in string[] incls) {
     auto binout = testEnv.outdir ~ "binary";
 
     Args args;


### PR DESCRIPTION
Changed the default for c/c++ to not sort.
Should work well because they are sorted by the function/methods.

Plantuml though need to be sorted because the unique ID is derived
from the absolute path.