### PR TITLE
The file path in a compilation database isn't normalized

### DIFF
--- a/source/application/types.d
+++ b/source/application/types.d
@@ -1,4 +1,3 @@
-// Written in the D programming language.
 /**
 Date: 2015-2016, Joakim Brännström
 License: MPL-2, Mozilla Public License 2.0


### PR DESCRIPTION
which makes the --in=... from the user fail in mysterious ways from
the users perspective.