### PR TITLE
Fix global unique identifiers to ensure they are not duplicated

### DIFF
--- a/source/cpptooling/analyzer/clang/type.d
+++ b/source/cpptooling/analyzer/clang/type.d
@@ -52,29 +52,11 @@ import cpptooling.data.symbol.container : Container;
 import cpptooling.data.symbol.types : USRType;
 import cpptooling.utility.clang : logNode;
 
-private size_t _nextSequence;
-
-static this() {
-    // Use a fixed number to minimize the difference between two generated
-    // diagrams. For example makes it possible to diff the generated data.
-    //
-    // It is extremly important to minimize differences.
-    // Diffs are used as the basis to evaluate changes.
-    // No diff, no evaluation needed from an architectural point of view.
-    // A change? Further inspection needed.
-    _nextSequence = 42;
-}
-
 private string nextSequence() @safe {
     import std.conv : text;
+    import cpptooling.utility.global_unique : nextNumber;
 
-    if (_nextSequence == size_t.max) {
-        _nextSequence = size_t.min;
-    }
-
-    _nextSequence += 1;
-
-    return text(_nextSequence);
+    return text(nextNumber);
 }
 
 /// Returns: Filter node to only return those that are a typeref.

--- a/source/cpptooling/data/representation.d
+++ b/source/cpptooling/data/representation.d
@@ -60,22 +60,11 @@ version (unittest) {
     }
 }
 
-private size_t _nextUSR;
-
-static this() {
-    // Keeping it fixed to make it easier to debug, read the logs. Aka
-    // reproduce the result.
-    _nextUSR = 42;
-}
-
-/// Generate the next thread unique ID.
+/// Generate the next globally unique ID.
 size_t nextUniqueID() @safe nothrow {
-    if (_nextUSR == size_t.max) {
-        _nextUSR = size_t.min;
-    }
+    import cpptooling.utility.global_unique : nextNumber;
 
-    _nextUSR += 1;
-    return _nextUSR;
+    return nextNumber;
 }
 
 /** Construct a USR that is ensured to be unique.

--- a/source/cpptooling/utility/global_unique.d
+++ b/source/cpptooling/utility/global_unique.d
@@ -1,0 +1,45 @@
+/**
+Copyright: Copyright (c) 2017, Joakim Brännström. All rights reserved.
+License: MPL-2
+Author: Joakim Brännström (joakim.brannstrom@gmx.com)
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+Contains facilities to generate globally unique numbers.
+*/
+module cpptooling.utility.global_unique;
+
+private shared(size_t) _nextSequence;
+
+static this() {
+    // Use a fixed number to minimize the difference between two sets of
+    // generated data.
+    //
+    // Keeping it fixed to make it easier to debug, read the logs. Aka
+    // reproduce the result.
+    //
+    // It is extremly important to minimize differences.
+    // Diffs are used as the basis to evaluate changes.
+    // No diff, no evaluation needed from an architectural point of view.
+    // A change? Further inspection needed.
+    _nextSequence = 42;
+}
+
+size_t nextNumber() @trusted nothrow {
+    import core.atomic;
+
+    size_t rval;
+
+    synchronized {
+        if (_nextSequence == size_t.max) {
+            _nextSequence = size_t.min;
+        }
+
+        core.atomic.atomicOp!"+="(_nextSequence, 1);
+        rval = _nextSequence;
+    }
+
+    return rval;
+}


### PR DESCRIPTION
Numbers that must be unique are generated in thread local which mean
they may be repeated in sibling threads.

The uniqe numbers in representatin and ..clang/type.d must be globally
unique because they are both used for USR's

storage which mean that they may not be u