### PR TITLE
CxGlobaVariable may not be unique because the ID is

### DIFF
--- a/source/cpptooling/data/representation.d
+++ b/source/cpptooling/data/representation.d
@@ -382,7 +382,7 @@ struct CxGlobalVariable {
     this(USRType usr, TypeKindVariable var) @safe pure nothrow {
         this.usr = usr;
         this.variable = var;
-        setUniqueId(variable.name);
+        setUniqueId(usr);
     }
 
     this(USRType usr, TypeKindAttr type, CppVariable name) @safe pure nothrow {


### PR DESCRIPTION
based on the variable name.
Changed to USR which _should_ be more unique.