### PR TITLE
cpptestdouble: allow the user to control generation of test doubles

### DIFF
--- a/test/cpp_tests.d
+++ b/test/cpp_tests.d
@@ -108,7 +108,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/bug_wchar.hpp", testEnv);
-    p.dexParams ~= ["--file-restrict=.*bug_wchar.hpp"];
+    p.dexParams ~= ["--file-restrict=.*bug_wchar.hpp", "--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     runTestFile(p, testEnv);
 }
@@ -176,7 +176,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/exclude_self.hpp", testEnv);
-    p.dexParams ~= ["--file-exclude=.*/" ~ p.input_ext.baseName.toString];
+    p.dexParams ~= ["--file-exclude=.*/" ~ p.input_ext.baseName.toString, "--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     p.compileIncls ~= "-I" ~ (p.root ~ "dev/extra").toString;
 
@@ -189,6 +189,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/extern_in_ns.hpp", testEnv);
+    p.dexParams ~= ["--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     p.compileIncls ~= "-I" ~ (p.root ~ "dev/extra").toString;
 
@@ -201,6 +202,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/one_free_func.hpp", testEnv);
+    p.dexParams ~= ["--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     runTestFile(p, testEnv);
 }
@@ -209,6 +211,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/functions_in_ns.hpp", testEnv);
+    p.dexParams ~= ["--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     runTestFile(p, testEnv);
 }
@@ -217,6 +220,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/have_root.hpp", testEnv);
+    p.dexParams ~= ["--gen-free-func"];
     p.compileFlags ~= ["-DTEST_INCLUDE"];
     p.compileIncls ~= "-I" ~ (p.root ~ "dev/extra").toString;
 
@@ -245,7 +249,7 @@ unittest {
     auto p = genTestParams("compile_db/single_file_main.hpp", testEnv);
 
     // find compilation flags by looking up how single_file_main.c was compiled
-    p.dexParams ~= ["--compile-db=" ~ (p.root ~ "compile_db/single_file_db.json")
+    p.dexParams ~= ["--gen-free-func", "--compile-db=" ~ (p.root ~ "compile_db/single_file_db.json")
         .toString, "--file-restrict=.*/single_file.hpp"];
 
     p.compileIncls ~= "-I" ~ (p.root ~ "compile_db/dir1").toString;
@@ -275,6 +279,7 @@ unittest {
 unittest {
     mixin(EnvSetup(globalTestdir));
     auto p = genTestParams("dev/ns_merge.hpp", testEnv);
+    p.dexParams ~= ["--gen-free-func"];
     p.skipCompile = Yes.skipCompile;
     runTestFile(p, testEnv);
 }
@@ -283,7 +288,7 @@ unittest {
 unittest {
     mixin(envSetup(globalTestdir));
     auto p = genTestParams("stage_2/bug_multiple_includes.hpp", testEnv);
-    p.dexParams ~= ["--in=" ~ (p.root ~ "stage_2/bug_multiple_includes.hpp")
+    p.dexParams ~= ["--gen-free-func", "--in=" ~ (p.root ~ "stage_2/bug_multiple_includes.hpp")
         .toString, "--in=" ~ (p.root ~ "stage_2/bug_multiple_includes.hpp").toString];
     runTestFile(p, testEnv);
 }


### PR DESCRIPTION
of free functions.