### PR TITLE
test: missing that dextool binaries must be built before

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ if(BUILD_TEST)
     enable_testing()
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R ".*unittest_")
     add_custom_target(check_integration COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "${INTEGRATION_TEST}")
+    add_custom_target(check_integration_make_all
+        COMMAND cmake --build ${CMAKE_BINARY_DIR}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+    add_dependencies(check_integration check_integration_make_all)
 endif()
 
 # Generally, we want to install everything into CMAKE_INSTALL_PREFIX, but when

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,6 +18,9 @@ This gives access to the make target _test_.
 
 To run the tests:
 ```sh
-make check # runs unittests
+# builds and runs the unittests
+make check
+
+# builds and runs the integration tests
 make check_integration
 ```


### PR DESCRIPTION
integration tests can be executed.