### PR TITLE
cpptooling: remove redundant test code from older versions of

### DIFF
--- a/source/cpptooling/analyzer/clang/ast/tree.d
+++ b/source/cpptooling/analyzer/clang/ast/tree.d
@@ -27,11 +27,7 @@ import cpptooling.analyzer.clang.ast.translationunit;
 import cpptooling.analyzer.clang.ast.nodes : CXCursorKind_PrefixLen;
 
 version (unittest) {
-    import unit_threaded : Name, shouldEqual, shouldBeTrue;
-} else {
-    private struct Name {
-        string name_;
-    }
+    import unit_threaded : shouldEqual, shouldBeTrue;
 }
 
 /**
@@ -160,7 +156,7 @@ string wrapCursor(alias visitor, alias cursor)(immutable(string)[] cases) {
     return result;
 }
 
-@Name("Should be a bounch of 'case'")
+@("Should be a bounch of 'case'")
 unittest {
     import std.conv : to;
 
@@ -178,7 +174,7 @@ case Dummy.xCase2: auto wrapped = new Case2(cursor); visitor.visit(wrapped); bre
 ");
 }
 
-@Name("A name for the test")
+@("A name for the test")
 @safe unittest {
     import cpptooling.analyzer.clang.ast : Visitor;
     import cpptooling.analyzer.clang.ast.nodes;

--- a/source/cpptooling/analyzer/clang/ast/visitor.d
+++ b/source/cpptooling/analyzer/clang/ast/visitor.d
@@ -13,12 +13,8 @@ version (unittest) {
     import std.algorithm : map, splitter;
     import std.array : array;
     import std.string : strip;
-    import unit_threaded : Name, shouldEqual;
+    import unit_threaded : shouldEqual;
     import test.extra_should : shouldEqualPretty;
-} else {
-    private struct Name {
-        string name_;
-    }
 }
 
 mixin template generateIndentIncrDecr() {
@@ -32,7 +28,7 @@ mixin template generateIndentIncrDecr() {
     }
 }
 
-@Name("Should be an instane of a Visitor")
+@("Should be an instane of a Visitor")
 unittest {
     import cpptooling.analyzer.clang.ast.base_visitor;
 


### PR DESCRIPTION
unit-threaded.