### PR TITLE
clang: the check always failed because the comparson is between enums of

### DIFF
--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -512,6 +512,21 @@ struct Cursor {
         return clang_isUnexposed(cx.kind) != 0;
     }
 
+    /// Return: if the underlying type is an enum.
+    @property bool isUnderlyingTypeEnum() const @trusted {
+        auto underlying = typedefUnderlyingType;
+        if (!underlying.isValid) {
+            return false;
+        }
+
+        auto decl = underlying.declaration;
+        if (!decl.isValid) {
+            return false;
+        }
+
+        return decl.type.isEnum;
+    }
+
     /// Return: if cursor is null/empty.
     @property bool isEmpty() const @trusted {
         return clang_Cursor_isNull(cx) != 0;
@@ -729,21 +744,6 @@ struct EnumCursor {
      */
     @property ulong unsignedValue() @trusted {
         return clang_getEnumConstantDeclUnsignedValue(cx);
-    }
-
-    /// Return: if the underlying type is an enum.
-    @property bool isUnderlyingTypeEnum() @trusted {
-        auto underlying = typedefUnderlyingType;
-        if (!underlying.isValid) {
-            return false;
-        }
-
-        auto decl = underlying.declaration;
-        if (!decl.isValid) {
-            return false;
-        }
-
-        return decl.enum_.kind == CXTypeKind.CXType_Enum;
     }
 
     /// Return: if the type of the enum is signed.

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     ${CMAKE_SOURCE_DIR}/source/test/component/scratch.d
 
     ${CMAKE_SOURCE_DIR}/source/test/component/analyzer/cpp_class_visitor.d
+    ${CMAKE_SOURCE_DIR}/source/test/component/analyzer/test_clang.d
     ${CMAKE_SOURCE_DIR}/source/test/component/analyzer/type.d
     ${CMAKE_SOURCE_DIR}/source/test/component/analyzer/utility.d
 

--- a/source/test/component/analyzer/test_clang.d
+++ b/source/test/component/analyzer/test_clang.d
@@ -1,0 +1,76 @@
+/**
+Copyright: Copyright (c) 2017, Joakim Brännström. All rights reserved.
+License: MPL-2
+Author: Joakim Brännström (joakim.brannstrom@gmx.com)
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+This module test the visitor, ast and interaction with Clang.
+*/
+module test.component.analyzer.test_clang;
+
+import std.typecons : Yes;
+
+import test.clang_util;
+import test.helpers;
+
+import cpptooling.analyzer.clang.ast;
+import cpptooling.analyzer.clang.context : ClangContext;
+import cpptooling.analyzer.clang.cursor_logger : logNode, mixinNodeLog;
+import cpptooling.utility.virtualfilesystem : FileName, Content;
+
+version (unittest) {
+    import unit_threaded : shouldEqual, shouldBeFalse, shouldBeTrue;
+}
+
+final class TestVisitor : Visitor {
+    import cpptooling.analyzer.clang.ast;
+
+    alias visit = Visitor.visit;
+    mixin generateIndentIncrDecr;
+
+    bool underlyingIsEnum;
+    string typedefSpelling;
+
+    override void visit(const(TranslationUnit) v) {
+        mixin(mixinNodeLog!());
+        v.accept(this);
+    }
+
+    override void visit(const(TypedefDecl) v) {
+        mixin(mixinNodeLog!());
+
+        if (v.cursor.spelling == "MyType") {
+            typedefSpelling = v.cursor.spelling;
+            underlyingIsEnum = v.cursor.isUnderlyingTypeEnum;
+        }
+    }
+}
+
+@("shall detect that the underlying of the typedef is an enum kind")
+unittest {
+    immutable code = `
+enum EnumFoo {
+    Foo
+};
+
+    typedef EnumFoo MyType;
+`;
+
+    // arrange
+    auto ctx = ClangContext(Yes.useInternalHeaders, Yes.prependParamSyntaxOnly);
+    ctx.virtualFileSystem.openAndWrite(cast(FileName) "/issue.hpp", cast(Content) code);
+    auto tu = ctx.makeTranslationUnit("/issue.hpp");
+    auto visitor = new TestVisitor;
+
+    // act
+    auto ast = ClangAST!(typeof(visitor))(tu.cursor);
+    ast.accept(visitor);
+
+    // assert
+    checkForCompilerErrors(tu).shouldBeFalse;
+    visitor.typedefSpelling.shouldEqual("MyType");
+    visitor.underlyingIsEnum.shouldBeTrue;
+}

--- a/source/test/component/scratch.d
+++ b/source/test/component/scratch.d
@@ -9,5 +9,8 @@ This file shall always be empty in the git master branch.
 */
 module test.component.scratch;
 
+import std.typecons : Yes;
+
 import unit_threaded;
 import test.clang_util;
+import test.helpers;

--- a/source/test/ut_main.d
+++ b/source/test/ut_main.d
@@ -15,6 +15,7 @@ int main(string[] args) {
     //dfmt off
     return args.runTests!(
                           "test.component.analyzer.cpp_class_visitor",
+                          "test.component.analyzer.test_clang",
                           "test.component.analyzer.type",
                           "test.component.analyzer.utility",
                           "test.component.scratch",


### PR DESCRIPTION
different types.