### PR TITLE
test: adjust recursive adding of files to better

### DIFF
--- a/test/source/dextool_test/compiler.d
+++ b/test/source/dextool_test/compiler.d
@@ -26,11 +26,18 @@ auto outputToDefaultBinary(BuildCommandRun br) {
     return br.addArg("-o" ~ (br.outdir ~ "binary").escapePath);
 }
 
-/// Add recursively all files in outdir with extension ext (including dot)
-auto addFilesFromOutdir(BuildCommandRun br, string ext) {
+/** Add recursively all files in outdir with extension ext (including dot)
+ *
+ * Params:
+ *  br = builder param to extend
+ *  ext = extension to filter on
+ *  exclude = files to exclude
+ */
+auto addFilesFromOutdirWithExtension(BuildCommandRun br, string ext, string[] exclude) {
     import dextool_test.utils : recursiveFilesWithExtension;
 
-    foreach (a; recursiveFilesWithExtension(br.outdir, ext)) {
+    foreach (a; recursiveFilesWithExtension(br.outdir, ext).filter!(a => !canFind(exclude,
+            a.baseName.toString))) {
         br.addArg(a);
     }
 

--- a/test/source/dextool_test/utils.d
+++ b/test/source/dextool_test/utils.d
@@ -524,7 +524,8 @@ string testId(uint line = __LINE__) {
 auto recursiveFilesWithExtension(Path dir, string ext) {
     // dfmt off
     return std.file.dirEntries(dir.toString, SpanMode.depth)
-        .filter!(a => extension(a) == ext)
+        .filter!(a => a.isFile)
+        .filter!(a => extension(a.name) == ext)
         .map!(a => Path(a));
     // dfmt on
 }


### PR DESCRIPTION
match the use case.

Only files are interesting to add.
Change the name to not easily be mixed up with addFilesFromOutdir.
It is a common case to want to exclude certain files.