### PR TITLE
cmake: fix recursive creation of symlinks on slow filesystems

### DIFF
--- a/plugin/fuzzer/CMakeLists.txt
+++ b/plugin/fuzzer/CMakeLists.txt
@@ -55,7 +55,6 @@ compile_d_integration_test(${EXE_NAME} "${CMAKE_SOURCE_DIR}/test/integration_mai
 # Additional test environment
 if (BUILD_TEST)
     execute_process(
-        COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/support
-        COMMAND ln -sf ${CMAKE_CURRENT_LIST_DIR}/support ${CMAKE_CURRENT_BINARY_DIR}/support
+        COMMAND ${CMAKE_SOURCE_DIR}/symlink.sh ${CMAKE_CURRENT_LIST_DIR}/support ${CMAKE_CURRENT_BINARY_DIR}/support
         )
 endif()

--- a/test/dextool_integration_test.cmake
+++ b/test/dextool_integration_test.cmake
@@ -11,8 +11,6 @@ set(flags "-I${CMAKE_SOURCE_DIR}/test/scriptlike/src -I${CMAKE_SOURCE_DIR}/test/
 
 # Setup expected test environment around the integration test binary
 execute_process(
-    COMMAND rm -f ${CMAKE_BINARY_DIR}/fused_gmock
-    COMMAND rm -f ${CMAKE_BINARY_DIR}/testdata
-    COMMAND ln -sf ${CMAKE_CURRENT_LIST_DIR}/fused_gmock ${CMAKE_BINARY_DIR}/fused_gmock
-    COMMAND ln -sf ${CMAKE_CURRENT_LIST_DIR}/testdata ${CMAKE_BINARY_DIR}/testdata
+    COMMAND ${CMAKE_SOURCE_DIR}/symlink.sh ${CMAKE_CURRENT_LIST_DIR}/fused_gmock ${CMAKE_BINARY_DIR}/fused_gmock
+    COMMAND ${CMAKE_SOURCE_DIR}/symlink.sh ${CMAKE_CURRENT_LIST_DIR}/testdata ${CMAKE_BINARY_DIR}/testdata
 )


### PR DESCRIPTION
such as NFS.