### PR TITLE
cmake: make the dependencies explicit on the libs that required

### DIFF
--- a/dextool_clang.cmake
+++ b/dextool_clang.cmake
@@ -23,4 +23,4 @@ set(flags
 compile_d_static_lib(dextool_clang "${SRC_FILES}" "${flags}" "" "dextool_libclang")
 
 list(APPEND SRC_FILES "${CMAKE_SOURCE_DIR}/clang/ut_main.d")
-compile_d_unittest(dextool_clang "${SRC_FILES}" "${flags}" "${LIBCLANG_LDFLAGS}" "dextool_libclang")
+compile_d_unittest(dextool_clang "${SRC_FILES}" "${flags}" "" "dextool_libclang")

--- a/dextool_cpptooling.cmake
+++ b/dextool_cpptooling.cmake
@@ -67,4 +67,4 @@ compile_d_static_lib(dextool_cpptooling
     "dextool_clang;dextool_dextool;dextool_libclang;dextool_dsrcgen;dextool_libclang")
 
 list(APPEND SRC_FILES "${CMAKE_SOURCE_DIR}/source/cpptooling/ut_main.d")
-compile_d_unittest(dextool_cpptooling "${SRC_FILES}" "${flags}" "${LIBCLANG_LDFLAGS}" "dextool_clang;dextool_dextool;dextool_libclang;dextool_dsrcgen")
+compile_d_unittest(dextool_cpptooling "${SRC_FILES}" "${flags}" "" "dextool_clang;dextool_dextool;dextool_libclang;dextool_dsrcgen")

--- a/dextool_dextool.cmake
+++ b/dextool_dextool.cmake
@@ -27,5 +27,5 @@ list(APPEND SRC_FILES "${CMAKE_SOURCE_DIR}/source/dextool/ut_main.d")
 compile_d_unittest(dextool_dextool
     "${SRC_FILES}"
     "${flags}"
-    "${LIBCLANG_LDFLAGS}"
-    "dextool_cpptooling")
+    ""
+    "dextool_cpptooling;dextool_libclang")


### PR DESCRIPTION
the llvm/clang flags.