### PR TITLE
clang: remove function from the generic cursor that is covered

### DIFF
--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -368,11 +368,6 @@ import clang.Visitor;
         return IncludeCursor(this);
     }
 
-    string includedPath() @trusted {
-        auto file = clang_getIncludedFile(cx);
-        return toD(clang_getFileName(file));
-    }
-
     @property Visitor all() const {
         return Visitor(this);
     }


### PR DESCRIPTION
by the specialization IncludeCursor.