### PR TITLE
cpptestdouble: fix not generating pretty printers for structs

### DIFF
--- a/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/backend/generate_cpp.d
+++ b/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/backend/generate_cpp.d
@@ -198,7 +198,7 @@ void generateForEach(ref ImplData impl, ref CppNamespace ns, Parameters params,
         generateFuncImpl(a, ns_data.impl().base);
     }
 
-    foreach (a; impl.root.classRange.filter!(a => impl.lookup(a.id) == Kind.gtestPrettyPrint)) {
+    foreach (a; ns.classRange.filter!(a => impl.lookup(a.id) == Kind.gtestPrettyPrint)) {
         auto hdr = ns_data.gtestPPHdr(a.resideInNs, a.name);
         generateGtestPrettyEqual(a.memberPublicRange, a.fullyQualifiedName,
                 cast(string) params.getMainNs, container, hdr);

--- a/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/frontend/frontend.d
+++ b/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/frontend/frontend.d
@@ -27,7 +27,7 @@ import dextool.type : AbsolutePath, CustomHeader, DextoolVersion,
 
 import dextool.plugin.cpptestdouble.backend : Controller, Parameters, Products,
     Transform;
-import dextool.plugin.cpptestdouble.frontend.raw_args : ConfigBool,
+import dextool.plugin.cpptestdouble.frontend.raw_args : Config_YesNo,
     RawConfiguration, XmlConfig;
 
 struct FileData {
@@ -172,8 +172,8 @@ class CppTestDoubleVariant : Controller, Parameters, Products {
         return this;
     }
 
-    auto argGtestPODPrettyPrint(ConfigBool a) {
-        this.gtestPP = cast(Flag!"GtestPODPrettyPrint")(a == ConfigBool.yes ? true : false);
+    auto argGtestPODPrettyPrint(Config_YesNo a) {
+        this.gtestPP = cast(Flag!"GtestPODPrettyPrint")(cast(bool) a);
         return this;
     }
 

--- a/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/frontend/raw_args.d
+++ b/plugin/cpptestdouble/source/dextool/plugin/cpptestdouble/frontend/raw_args.d
@@ -17,8 +17,10 @@ import dextool.plugin.types : CliOptionParts;
 
 static import dextool.xml;
 
-/// Represent a yes/no configuration option
-enum ConfigBool {
+/// Represent a yes/no configuration option.
+/// Using an explicit name so the help text is improved in such a way that the
+/// user understand that the choices are between yes/no.
+enum Config_YesNo {
     no,
     yes
 }
@@ -47,7 +49,7 @@ struct RawConfiguration {
     bool shortPluginHelp;
     bool help;
     bool gmock;
-    ConfigBool gtestPODPrettyPrint = ConfigBool.yes;
+    Config_YesNo gtestPODPrettyPrint = Config_YesNo.yes;
     bool generatePreInclude;
     bool genPostInclude;
 

--- a/plugin/cpptestdouble/test/gtest_integration.d
+++ b/plugin/cpptestdouble/test/gtest_integration.d
@@ -25,3 +25,34 @@ unittest {
     makeCommand(testEnv, defaultBinary)
         .run;
 }
+
+@("shall generate pretty printers for structs in a namespace")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    makeDextool(testEnv)
+        .addInputArg(pluginTestData ~ "stage_3/test_pretty_print_in_ns.hpp")
+        .run;
+    dextool_test.makeCompile(testEnv, "g++")
+        .addInclude(pluginTestData ~ "stage_3")
+        .addArg(pluginTestData ~ "stage_3/test_pretty_print_in_ns.cpp")
+        .addFileFromOutdir("test_double_fused_gtest.cpp")
+        .addGtestArgs
+        .outputToDefaultBinary
+        .run;
+    auto r = makeCommand(testEnv, defaultBinary)
+        .run;
+
+    r.stdout.sliceContains([
+                           "Expected: a",
+                           "Which is: x:1",
+                           "To be equal to: b",
+                           "Which is: x:2",
+    ]);
+
+    r.stdout.sliceContains([
+      "Expected: a",
+      "Which is: y:1",
+      "To be equal to: b",
+      "Which is: y:2"
+    ]);
+}

--- a/plugin/cpptestdouble/testdata/stage_3/test_order_req_for_recursive_structs.cpp
+++ b/plugin/cpptestdouble/testdata/stage_3/test_order_req_for_recursive_structs.cpp
@@ -1,0 +1,10 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2017
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+#include "test_pretty_print_in_ns.hpp"
+
+#include "test_double_gmock.hpp"
+
+int main(int argc, char** argv) {
+    return 0;
+}

--- a/plugin/cpptestdouble/testdata/stage_3/test_pretty_print_in_ns.cpp
+++ b/plugin/cpptestdouble/testdata/stage_3/test_pretty_print_in_ns.cpp
@@ -1,0 +1,32 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2017
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+#ifndef TEST_PRETTY_PRINT_IN_NS_CPP
+#define TEST_PRETTY_PRINT_IN_NS_CPP
+
+#include "test_double_gmock.hpp"
+
+void test_using_gtest_expects() {
+    ns1::A a = {1};
+    ns1::A b = {2};
+
+    EXPECT_EQ(a, a);
+    EXPECT_EQ(a, b);
+}
+
+void test_using_from_nested_ns() {
+    ns1::ns2::B a = {1};
+    ns1::ns2::B b = {2};
+
+    EXPECT_EQ(a, a);
+    EXPECT_EQ(a, b);
+}
+
+int main(int argc, char** argv) {
+    test_using_gtest_expects();
+    test_using_from_nested_ns();
+
+    return 0;
+}
+
+#endif // TEST_PRETTY_PRINT_IN_NS_CPP

--- a/plugin/cpptestdouble/testdata/stage_3/test_pretty_print_in_ns.hpp
+++ b/plugin/cpptestdouble/testdata/stage_3/test_pretty_print_in_ns.hpp
@@ -1,0 +1,24 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2017
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+#ifndef TEST_PRETTY_PRINT_IN_NS_HPP
+#define TEST_PRETTY_PRINT_IN_NS_HPP
+
+namespace ns1 {
+
+struct A {
+    int x;
+};
+
+namespace ns2 {
+
+struct B {
+    int y;
+};
+
+
+} // NS: ns2
+
+} // NS: ns1
+
+#endif // TEST_PRETTY_PRINT_IN_NS_HPP


### PR DESCRIPTION
in namespaces.