### PR TITLE
mutate: no user msg when the tool mode isn't specified which

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
@@ -99,7 +99,8 @@ ExitStatusType runMutate(Frontend fe) {
 
     final switch (fe.toolMode) {
     case ToolMode.none:
-        break;
+        logger.error("No --mode specified");
+        return ExitStatusType.Errors;
     case ToolMode.analyzer:
         import dextool.plugin.mutate.backend : runAnalyzer;
 


### PR DESCRIPTION
makes it hard for the user to understand why the tool does nothing.