### PR TITLE
application: the name of the plugin isn't necessary when calling a

### DIFF
--- a/plugin/compiledb/source/dextool/plugin/compiledb/raw_args.d
+++ b/plugin/compiledb/source/dextool/plugin/compiledb/raw_args.d
@@ -39,8 +39,8 @@ struct RawConfiguration {
         }
 
         if (args.length > 2) {
-            // the first two are the binaries name followed by the plugin
-            inCompileDb = args[2 .. $];
+            // the first is the binary itself
+            inCompileDb = args[1 .. $];
         }
     }
 

--- a/source/application/app_main.d
+++ b/source/application/app_main.d
@@ -56,7 +56,7 @@ auto parseMainCLI(const string[] args) {
         state = CLICategoryStatus.PluginList;
     }
 
-    string category = rem_args.length >= 2 ? rem_args[1] : "";
+    string category = rem_args.length >= 2 ? rem_args[1] : null;
 
     return CLIResult(state, category, loglevel);
 }
@@ -149,7 +149,7 @@ ExitStatusType runPlugin(CLIResult cli, string[] args) {
         foreach (p; plugins
                  .filter!(p => p.name == cli.category)
                  .takeOne) {
-            auto pid = spawnProcess([cast(string) p.path] ~ args[1 .. $]);
+            auto pid = spawnProcess([cast(string) p.path] ~ (args.length > 2 ? args[2 .. $] : null));
             exit_status = wait(pid) == 0 ? ExitStatusType.Ok : ExitStatusType.Errors;
             match_found = true;
         }


### PR DESCRIPTION
plugin because it knows what it is via arg[0]. Therefore stripping the
second argument.