### PR TITLE
mutate: multiple --restrict append to the default which result in the

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -45,7 +45,7 @@ struct ArgParser {
     string[] compileDb;
 
     string outputDirectory = ".";
-    string[] restrictDir = ["."];
+    string[] restrictDir;
 
     string db = "dextool_mutate.sqlite3";
     string mutationTester;
@@ -207,6 +207,9 @@ struct ArgParser {
             help = true;
             return;
         }
+
+        if (restrictDir.length == 0)
+            restrictDir = ["."];
 
         import std.algorithm : find;
         import std.array : array;


### PR DESCRIPTION
current directory always being part of the restricted directories.