### PR TITLE
mutate: the CLI command admin should be able to control what the mutants

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/admin.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/admin.d
@@ -20,13 +20,14 @@ import dextool.plugin.mutate.type : MutationKind;
 import dextool.plugin.mutate.backend.database : Database;
 import dextool.plugin.mutate.backend.type : Mutation;
 
-ExitStatusType runAdmin(ref Database db, MutationKind[] mutations, Mutation.Status status) @safe nothrow {
+ExitStatusType runAdmin(ref Database db, MutationKind[] mutations,
+        Mutation.Status status, Mutation.Status to_status) @safe nothrow {
     import dextool.plugin.mutate.backend.utility;
 
     const auto kinds = dextool.plugin.mutate.backend.utility.toInternal(mutations);
 
     try {
-        db.resetMutant(kinds, status);
+        db.resetMutant(kinds, status, to_status);
     }
     catch (Exception e) {
         logger.error(e.msg).collectException;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -211,12 +211,12 @@ struct Database {
 
     /** Reset all mutations of kinds with the status `st` to unknown.
      */
-    void resetMutant(const Mutation.Kind[] kinds, Mutation.Status st) @trusted {
+    void resetMutant(const Mutation.Kind[] kinds, Mutation.Status st, Mutation.Status to_st) @trusted {
         import std.algorithm : map;
         import std.format : format;
 
-        auto s = format("UPDATE mutation SET status=0 WHERE status == %s AND kind IN (%(%s,%))",
-                st.to!long, kinds.map!(a => cast(int) a));
+        auto s = format("UPDATE mutation SET status=%s WHERE status == %s AND kind IN (%(%s,%))",
+                to_st.to!long, st.to!long, kinds.map!(a => cast(int) a));
         auto stmt = db.prepare(s);
         stmt.execute;
     }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant.d
@@ -831,7 +831,7 @@ nothrow:
         driver_sig = TestDriverSignal.stop;
 
         try {
-            data.db.resetMutant(data.mutKind, Mutation.Status.timeout);
+            data.db.resetMutant(data.mutKind, Mutation.Status.timeout, Mutation.Status.unknown);
             driver_sig = TestDriverSignal.next;
         }
         catch (Exception e) {

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -65,6 +65,7 @@ struct ArgParser {
     ReportLevel reportLevel;
 
     Mutation.Status mutantStatus;
+    Mutation.Status mutantToStatus = Mutation.Status.unknown;
 
     ToolMode toolMode;
 
@@ -162,7 +163,8 @@ struct ArgParser {
             help_info = getopt(args, std.getopt.config.keepEndOfOptions,
                 "db", db_help, &db,
                 "mutant", "mutants to operate on " ~ format("[%(%s|%)]", [EnumMembers!MutationKind]), &mutation,
-                "status", "reset mutants to unknown which currently have status " ~ format("[%(%s|%)]", [EnumMembers!(Mutation.Status)]), &mutantStatus,
+                "status", "change the state of the mutants --to-status unknown which currently have status " ~ format("[%(%s|%)]", [EnumMembers!(Mutation.Status)]), &mutantStatus,
+                "to-status", "reset mutants to state (default: unknown) " ~ format("[%(%s|%)]", [EnumMembers!(Mutation.Status)]), &mutantToStatus,
                 );
             // dfmt on
         }

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
@@ -44,6 +44,7 @@ private:
     ReportKind reportKind;
     ReportLevel reportLevel;
     Mutation.Status mutantStatus;
+    Mutation.Status mutantToStatus;
 }
 
 @safe:
@@ -69,6 +70,7 @@ auto buildFrontend(ref ArgParser p) {
     r.reportKind = p.reportKind;
     r.reportLevel = p.reportLevel;
     r.mutantStatus = p.mutantStatus;
+    r.mutantToStatus = p.mutantToStatus;
 
     r.restrictDir = p.restrictDir.map!(a => AbsolutePath(FileName(a))).array;
     r.outputDirectory = AbsolutePath(FileName(p.outputDirectory));
@@ -127,7 +129,7 @@ ExitStatusType runMutate(Frontend fe) {
     case ToolMode.admin:
         import dextool.plugin.mutate.backend : runAdmin;
 
-        return runAdmin(db, fe.mutation, fe.mutantStatus);
+        return runAdmin(db, fe.mutation, fe.mutantStatus, fe.mutantToStatus);
     }
 }
 


### PR DESCRIPTION
are change to.
This solve the problem where one may want to "force" mutants into the
timeout status because there are "too many" of them that takes too long
time to retest.