### PR TITLE
clang: fix memory leak because Index and TranslationUnit aren't

### DIFF
--- a/clang/Cursor.d
+++ b/clang/Cursor.d
@@ -428,8 +428,7 @@ import clang.Visitor;
         //TODO i'm not sure this is a good solution... investigate.
         try {
             return clang_hashCursor(cast(CXCursor) cx);
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             return 0;
         }
     }
@@ -637,7 +636,7 @@ import clang.Visitor;
         return clang_getCursorVisibility(cx);
     }
 
-    private static CXCursorKind[string] queryPredefined() {
+    private static CXCursorKind[string] queryPredefined() @trusted {
         import clang.Index;
         import clang.TranslationUnit;
 

--- a/clang/Index.d
+++ b/clang/Index.d
@@ -58,17 +58,26 @@ import clang.c.Index;
  * (which gives the indexer the same performance benefit as the compiler).
  */
 struct Index {
+    import std.array : Appender;
+    import std.typecons : RefCounted;
     import clang.Util;
 
     static private struct ContainIndex {
         mixin CX!("Index");
+        Appender!(CXTranslationUnit[]) tus;
 
-        ~this() @safe {
+        void put(CXTranslationUnit tu) @safe {
+            tus.put(tu);
+        }
+
+        ~this() @trusted {
+            foreach (tu; tus.data)
+                clang_disposeTranslationUnit(tu);
             dispose();
         }
     }
 
-    ContainIndex cx;
+    RefCounted!ContainIndex cx;
     alias cx this;
 
     @disable this(this);

--- a/clang/TranslationUnit.d
+++ b/clang/TranslationUnit.d
@@ -27,10 +27,8 @@ struct TranslationUnit {
 
     static private struct ContainTU {
         mixin CX!("TranslationUnit");
-
-        ~this() @safe {
-            dispose();
-        }
+        // no need to call dispose because disposing of the Index also cleans
+        // up all TranslationUnits.
     }
 
     ContainTU cx;
@@ -61,7 +59,9 @@ struct TranslationUnit {
                                       );
         // dfmt on
 
-        return TranslationUnit(p);
+        auto tu = TranslationUnit(p);
+        index.cx.put(p);
+        return tu;
     }
 
     /** Convenient function to create a TranslationUnit from source code via a
@@ -74,7 +74,7 @@ struct TranslationUnit {
      */
     static TranslationUnit parseString(ref Index index, string source, string[] commandLineArgs,
             CXUnsavedFile[] unsavedFiles = null,
-            uint options = CXTranslationUnit_Flags.detailedPreprocessingRecord) @trusted {
+            uint options = CXTranslationUnit_Flags.detailedPreprocessingRecord) @safe {
         import std.string : toStringz;
 
         string path = randomSourceFileName;
@@ -87,10 +87,7 @@ struct TranslationUnit {
 
         auto in_memory_files = unsavedFiles ~ [file];
 
-        auto translationUnit = TranslationUnit.parse(index, path,
-                commandLineArgs, in_memory_files, options);
-
-        return translationUnit;
+        return TranslationUnit.parse(index, path, commandLineArgs, in_memory_files, options);
     }
 
     private static string randomSourceFileName() @safe {

--- a/source/cpptooling/analyzer/clang/context.d
+++ b/source/cpptooling/analyzer/clang/context.d
@@ -68,7 +68,7 @@ struct ClangContext {
      *   prependParamSyntaxOnly = prepend the flag -fsyntax-only to instantiated translation units.
      */
     this(Flag!"useInternalHeaders" useInternalHeaders,
-            Flag!"prependParamSyntaxOnly" prependParamSyntaxOnly) {
+            Flag!"prependParamSyntaxOnly" prependParamSyntaxOnly) @trusted {
         index = Index(false, false);
         virtualFileSystem = VirtualFileSystem();
 
@@ -77,7 +77,7 @@ struct ClangContext {
             import clang.Compiler : Compiler;
 
             Compiler compiler;
-            internal_header_arg = ["-I" ~ compiler.extraIncludePath];
+            internal_header_arg = compiler.extraIncludeFlags;
             foreach (hdr; compiler.extraHeaders) {
                 virtualFileSystem.openInMemory(cast(FileName) hdr.filename);
                 virtualFileSystem.write(cast(FileName) hdr.filename, cast(Content) hdr.content);
@@ -127,7 +127,7 @@ struct ClangContext {
 }
 
 @("shall be an instance")
-unittest {
+@system unittest {
     import std.typecons : Yes;
 
     auto ctx = ClangContext(Yes.useInternalHeaders, Yes.prependParamSyntaxOnly);

--- a/source/dextool/clang.d
+++ b/source/dextool/clang.d
@@ -39,7 +39,7 @@ private struct IncludeResult {
  * Returns: The first CompileCommand object which _probably_ has the flags needed to parse fname.
  */
 Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compdb,
-        FileName fname, ref const CompileCommandFilter flag_filter, const string[] extra_flags) {
+        FileName fname, ref const CompileCommandFilter flag_filter, const string[] extra_flags) @trusted {
     import std.algorithm : filter;
     import std.file : exists;
     import std.path : baseName;

--- a/source/dextool/utility.d
+++ b/source/dextool/utility.d
@@ -62,7 +62,7 @@ pure string[] prependLangFlagIfMissing(in string[] in_cflags, const PreferLang l
  * Returns: if the analyze was performed ok or errors occured
  */
 ExitStatusType analyzeFile(VisitorT, ClangContextT)(const AbsolutePath input_file,
-        const string[] cflags, VisitorT visitor, ref ClangContextT ctx) {
+        const string[] cflags, VisitorT visitor, ref ClangContextT ctx) @trusted {
     import std.file : exists;
 
     import cpptooling.analyzer.clang.ast : ClangAST;


### PR DESCRIPTION
disposed.