### PR TITLE
mutate: improve visualisation of redundant test cases

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
@@ -277,8 +277,8 @@ struct Markdown(Writer, TraceWriter) {
         }
 
         if (report_level != ReportLevel.summary) {
-            Table!2 tbl;
-            tbl.heading = ["TestCase", "Mutation ID"];
+            Table!3 tbl;
+            tbl.heading = ["TestCase", "Count", "Mutation ID"];
             auto stat = reportTestCaseFullOverlap(db, tbl);
 
             if (!tbl.empty) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
@@ -277,13 +277,12 @@ struct Markdown(Writer, TraceWriter) {
         }
 
         if (report_level != ReportLevel.summary) {
-            Table!1 tbl;
-            tbl.heading = ["TestCase"];
+            Table!2 tbl;
+            tbl.heading = ["TestCase", "Mutation ID"];
             auto stat = reportTestCaseFullOverlap(db, tbl);
 
             if (!tbl.empty) {
-                auto item = markdown.heading(
-                        "Redundant Test Cases (killing the exactly same mutants)");
+                auto item = markdown.heading("Redundant Test Cases (killing the same mutants)");
                 item.writeln(stat);
                 tbl.toString(Writer, fmt);
                 item.popHeading;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
@@ -274,9 +274,9 @@ import dextool.plugin.mutate.backend.report.type : ReportEvent;
         }
 
         if (ReportSection.tc_full_overlap in sections) {
-            logger.info("Redundant Test Cases (killing the exactly same mutants)");
-            Table!1 tbl;
-            tbl.heading = ["TestCase"];
+            logger.info("Redundant Test Cases (killing the same mutants)");
+            Table!2 tbl;
+            tbl.heading = ["TestCase", "Mutation ID"];
             auto stat = reportTestCaseFullOverlap(db, tbl);
             writeln(stat);
             writeln(tbl);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
@@ -275,8 +275,8 @@ import dextool.plugin.mutate.backend.report.type : ReportEvent;
 
         if (ReportSection.tc_full_overlap in sections) {
             logger.info("Redundant Test Cases (killing the same mutants)");
-            Table!2 tbl;
-            tbl.heading = ["TestCase", "Mutation ID"];
+            Table!3 tbl;
+            tbl.heading = ["TestCase", "Count", "Mutation ID"];
             auto stat = reportTestCaseFullOverlap(db, tbl);
             writeln(stat);
             writeln(tbl);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
@@ -342,9 +342,10 @@ void reportStatistics(ReportT)(ref Database db, const Mutation.Kind[] kinds, ref
  *
  * Returns: a string with statistics.
  */
-string reportTestCaseFullOverlap(ref Database db, ref Table!2 tbl) @safe nothrow {
+string reportTestCaseFullOverlap(ref Database db, ref Table!3 tbl) @safe nothrow {
     import std.algorithm : sort, map, filter, joiner;
     import std.array : array;
+    import std.conv : to;
     import std.format : format;
     import dextool.hash;
     import dextool.plugin.mutate.backend.database.type : TestCaseId;
@@ -382,13 +383,15 @@ string reportTestCaseFullOverlap(ref Database db, ref Table!2 tbl) @safe nothrow
                 typeof(tbl).Row r;
                 r[0] = name;
                 if (first) {
-                    r[1] = format("%-(%s,%)", mutid_mut[tcs.key]);
+                    auto muts = mutid_mut[tcs.key];
+                    r[1] = muts.length.to!string;
+                    r[2] = format("%-(%s,%)", muts);
                     first = false;
                 }
 
                 tbl.put(r);
             }
-            typeof(tbl).Row r = ["", ""];
+            typeof(tbl).Row r = ["", "", ""];
             tbl.put(r);
         }
 


### PR DESCRIPTION
test cases.
This hopefully improve the understanding for the user of why they
overlap.