### PR TITLE
mutate: (html) users cannot take fast actions on the mutation IDs

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
@@ -22,7 +22,8 @@ import dextool.plugin.mutate.backend.type;
 
 import dextool.plugin.mutate.backend.database.schema;
 public import dextool.plugin.mutate.backend.database.type;
-public import dextool.plugin.mutate.backend.database.standalone : spinSqlQuery;
+public import dextool.plugin.mutate.backend.database.standalone : spinSqlQuery,
+    MutantInfo;
 
 /** Wrapper for a sqlite3 database that provide a uniform, easy-to-use
  * interface for the mutation testing plugin.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/nodes.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/nodes.d
@@ -192,7 +192,7 @@ HtmlNode aHref(T)(T link, string desc, string anchor = null) {
     if (anchor.length == 0)
         n.put(format(`<a href="%s">%s</a>`, link, desc.encode));
     else
-        n.put(format(`<a href="%s#%s">%s</a>`, link, desc.encode, anchor));
+        n.put(format(`<a href="%s#%s">%s</a>`, link, anchor, desc.encode));
     return n;
 }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
@@ -164,6 +164,7 @@ void testGroups(const TestGroupStat test_g, HtmlNode n) {
     import std.array : array;
     import std.path : buildPath;
     import std.range : enumerate;
+    import dextool.plugin.mutate.backend.mutation_type : toUser;
 
     n.n("h3".Tag).put(test_g.description);
 
@@ -178,13 +179,16 @@ void testGroups(const TestGroupStat test_g, HtmlNode n) {
         r.td.put(d[1]);
     }
 
-    n.n("p".Tag).put("Mutation data per file. The killed mutants are those that where killed by this test group. Therefor the total here is less than the reported total.");
+    with (n.n("p".Tag)) {
+        put("Mutation data per file.");
+        put("The killed mutants are those that where killed by this test group.");
+        put("Therefor the total here is less than the reported total.");
+    }
     auto file_tbl = HtmlTable.make;
     n.put(file_tbl.root);
     file_tbl.root.putAttr("class", "overlap_tbl");
-    file_tbl.putColumn("File").putAttr("class", tableColumnHdrStyle);
-    file_tbl.putColumn("Alive").putAttr("class", tableColumnHdrStyle);
-    file_tbl.putColumn("Killed").putAttr("class", tableColumnHdrStyle);
+    foreach (c; ["File", "Alive", "Killed"])
+        file_tbl.putColumn(c).putAttr("class", tableColumnHdrStyle);
 
     foreach (const pkv; test_g.files
             .byKeyValue
@@ -197,18 +201,18 @@ void testGroups(const TestGroupStat test_g, HtmlNode n) {
 
         auto alive_ids = r.td;
         if (auto alive = pkv[0] in test_g.alive) {
-            foreach (a; (*alive).dup.sort) {
-                alive_ids.put(aHref(buildPath(htmlFileDir,
-                        pathToHtmlLink(path)), a.to!string, a.to!string));
+            foreach (a; (*alive).dup.sort!((a, b) => a.sloc.line < b.sloc.line)) {
+                alive_ids.put(aHref(buildPath(htmlFileDir, pathToHtmlLink(path)),
+                        format("%s:%s", a.kind.toUser, a.sloc.line), a.id.to!string));
                 alive_ids.put(" ");
             }
         }
 
         auto killed_ids = r.td;
         if (auto killed = pkv[0] in test_g.killed) {
-            foreach (a; (*killed).dup.sort) {
-                killed_ids.put(aHref(buildPath(htmlFileDir,
-                        pathToHtmlLink(path)), a.to!string, a.to!string));
+            foreach (a; (*killed).dup.sort!((a, b) => a.sloc.line < b.sloc.line)) {
+                killed_ids.put(aHref(buildPath(htmlFileDir, pathToHtmlLink(path)),
+                        format("%s:%s", a.kind.toUser, a.sloc.line), a.id.to!string));
                 killed_ids.put(" ");
             }
         }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
@@ -511,7 +511,8 @@ TestCaseOverlapStat reportTestCaseFullOverlap(ref Database db, const Mutation.Ki
 }
 
 class TestGroupStat {
-    import dextool.plugin.mutate.backend.database : MutationId, FileId;
+    import dextool.plugin.mutate.backend.database : MutationId, FileId,
+        MutantInfo;
 
     /// Human readable description for the test group.
     string description;
@@ -522,9 +523,9 @@ class TestGroupStat {
     /// Lookup for converting a id to a filename
     Path[FileId] files;
     /// Mutants alive in a file.
-    MutationId[][FileId] alive;
+    MutantInfo[][FileId] alive;
     /// Mutants killed in a file.
-    MutationId[][FileId] killed;
+    MutantInfo[][FileId] killed;
 }
 
 TestGroupStat reportTestGroups(ref Database db, const Mutation.Kind[] kinds, const(TestGroup) test_g) @safe {
@@ -582,9 +583,9 @@ TestGroupStat reportTestGroups(ref Database db, const Mutation.Kind[] kinds, con
     r.stats.total = tc_stat.total.length;
 
     // associate mutants with their file
-    foreach (const mid; db.getMutationIds(kinds, tc_stat.tcKilled.setToList!MutationStatusId)) {
-        auto fid = db.getFileId(mid);
-        r.killed[fid] ~= mid;
+    foreach (const m; db.getMutantsInfo(kinds, tc_stat.tcKilled.setToList!MutationStatusId)) {
+        auto fid = db.getFileId(m.id);
+        r.killed[fid] ~= m;
 
         if (fid !in r.files) {
             r.files[fid] = Path.init;
@@ -592,9 +593,9 @@ TestGroupStat reportTestGroups(ref Database db, const Mutation.Kind[] kinds, con
         }
     }
 
-    foreach (const mid; db.getMutationIds(kinds, tc_stat.alive.setToList!MutationStatusId)) {
-        auto fid = db.getFileId(mid);
-        r.alive[fid] ~= mid;
+    foreach (const m; db.getMutantsInfo(kinds, tc_stat.alive.setToList!MutationStatusId)) {
+        auto fid = db.getFileId(m.id);
+        r.alive[fid] ~= m;
 
         if (fid !in r.files) {
             r.files[fid] = Path.init;


### PR DESCRIPTION
By presenting kind:line it is easier for a user to get a quick overview
of the potential problems in the test group and the specific files.