### PR TITLE
mutate: paths from a diff should be absolute so they then can be turned

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
@@ -223,7 +223,8 @@ struct FileIndex {
         files.data.toIndex(indexh, htmlFileDir);
 
         File(stats_f, "w").write(makeStats(db, conf, humanReadableKinds, kinds));
-        File(user_f, "w").write(makeUserReport(db, conf, humanReadableKinds, kinds, diff));
+        File(user_f, "w").write(makeUserReport(db, conf, humanReadableKinds,
+                kinds, diff, fio.getOutputDir));
         File(buildPath(logDir, "index" ~ htmlExt), "w").write(indexh);
     }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_user.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_user.d
@@ -26,11 +26,13 @@ import dextool.plugin.mutate.backend.report.utility;
 import dextool.plugin.mutate.backend.type : Mutation;
 import dextool.plugin.mutate.config : ConfigReport;
 import dextool.plugin.mutate.type : MutationKind;
+import dextool.type : AbsolutePath;
 
 @safe:
 
 auto makeUserReport(ref Database db, ref const ConfigReport conf,
-        const(MutationKind)[] humanReadableKinds, const(Mutation.Kind)[] kinds, ref Diff diff) {
+        const(MutationKind)[] humanReadableKinds, const(Mutation.Kind)[] kinds,
+        ref Diff diff, AbsolutePath workdir) {
     import dextool.plugin.mutate.backend.report.html.tmpl : addStateTableCss;
 
     auto root = defaultHtml(format("Mutation Testing Report %(%s %) %s",
@@ -40,7 +42,7 @@ auto makeUserReport(ref Database db, ref const ConfigReport conf,
 
     root.body_.n("h2".Tag).put("User Report");
 
-    toHtml(reportDiff(db, kinds, diff), root.body_);
+    toHtml(reportDiff(db, kinds, diff, workdir), root.body_);
 
     return root;
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
@@ -679,7 +679,8 @@ class DiffReport {
     }
 }
 
-DiffReport reportDiff(ref Database db, const(Mutation.Kind)[] kinds, ref Diff diff) {
+DiffReport reportDiff(ref Database db, const(Mutation.Kind)[] kinds,
+        ref Diff diff, AbsolutePath workdir) {
     import std.algorithm : map;
     import dextool.plugin.mutate.backend.database : MutationId, FileId, MutantInfo,
         MutationStatus, MutationStatusId, MutationEntry, MutationStatusTime;
@@ -688,10 +689,10 @@ DiffReport reportDiff(ref Database db, const(Mutation.Kind)[] kinds, ref Diff di
 
     auto rval = new DiffReport;
 
-    foreach (kv; diff.byKeyValue) {
+    foreach (kv; diff.toRange(workdir)) {
         auto fid = db.getFileId(kv.key);
         if (fid.isNull) {
-            logger.info("File in diff do not exist in the database: ", kv.key);
+            logger.warning("This file in the diff has not been tested thus skipping it: ", kv.key);
             continue;
         }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -450,7 +450,8 @@ void printFileAnalyzeHelp(ref ArgParser ap) @safe {
             "Analyze and mutation of files will only be done on those inside this directory root");
     logger.info("  User input: ", ap.workArea.rawRoot);
     logger.info("  Real path: ", ap.workArea.outputDirectory);
-    logger.info("Further restricted to those inside these paths");
+    logger.info(ap.workArea.rawRestrict.length != 0,
+            "Further restricted to those inside these paths");
 
     assert(ap.workArea.rawRestrict.length == ap.workArea.restrictDir.length);
     foreach (idx; 0 .. ap.workArea.rawRestrict.length) {

--- a/plugin/mutate/test/test_report.d
+++ b/plugin/mutate/test/test_report.d
@@ -335,5 +335,7 @@ class ShallReportAliveMutantsOnChangedLine : SimpleAnalyzeFixture {
             .run;
 
         // Act
+        testConsecutiveSparseOrder!SubStr(["warning:"]).shouldNotBeIn(r.stdout);
+        testConsecutiveSparseOrder!SubStr(["warning:"]).shouldNotBeIn(r.stderr);
     }
 }

--- a/plugin/mutate/testdata/report_one_ror_mutation_point.cpp.diff
+++ b/plugin/mutate/testdata/report_one_ror_mutation_point.cpp.diff
@@ -1,5 +1,5 @@
---- build/plugin/mutate/plugin_testdata/report_one_ror_mutation_point.cpp	2018-11-18 21:25:46.631640690 +0100
-+++ build/plugin/mutate/plugin_testdata/report_one_ror_mutation_point.cpp	2018-11-18 21:26:17.003691847 +0100
+--- plugin_testdata/report_one_ror_mutation_point.cpp	2018-11-18 21:25:46.631640690 +0100
++++ plugin_testdata/report_one_ror_mutation_point.cpp	2018-11-18 21:26:17.003691847 +0100
 @@ -3,7 +3,7 @@
  /// @author Joakim Brännström (joakim.brannstrom@gmx.com)
  


### PR DESCRIPTION
into relative for lookup in the database.