### PR TITLE
simplify the triangle mutate example, e.g. by reducing the number of files

### DIFF
--- a/plugin/mutate/examples/triangle/1_setup.sh
+++ b/plugin/mutate/examples/triangle/1_setup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dextool mutate admin --init

--- a/plugin/mutate/examples/triangle/2_analyze.sh
+++ b/plugin/mutate/examples/triangle/2_analyze.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dextool mutate analyze --in src/triangle.c -- -Iinc

--- a/plugin/mutate/examples/triangle/3_test.sh
+++ b/plugin/mutate/examples/triangle/3_test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dextool mutate test

--- a/plugin/mutate/examples/triangle/4_report.sh
+++ b/plugin/mutate/examples/triangle/4_report.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dextool mutate report --section summary --section alive --section killed

--- a/plugin/mutate/examples/triangle/Makefile
+++ b/plugin/mutate/examples/triangle/Makefile
@@ -1,13 +1,59 @@
-CFLAGS = -Iinc
-LDFLAGS = -lm
+#
+# Obtain path to this Makefile
+#
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MAKEFILE_DIR  := $(dir $(MAKEFILE_PATH))
 
-all: triangle_test
 
-triangle_test:
-	$(CC) $(CFLAGS) src/triangle.c test/test_triangle.c $(LDFLAGS) -o $@
+#
+# Compilation parameters
+#
+CFLAGS  := -I$(MAKEFILE_DIR)/inc
+LDFLAGS := -lm
 
-test: triangle_test
-	./triangle_test
+SOURCE := $(MAKEFILE_DIR)/src/triangle.c
+TEST   := $(MAKEFILE_DIR)/test/test_triangle.c
+
+
+#
+# Mutation testing parameters
+#
+MUTATION_DB     := test_triangle.mut.db
+MUTATION_REPORT := html
+
+DEXTOOL ?= $(MAKEFILE_DIR)/../../../../build/dextool
+MFLAGS  := --db $(MUTATION_DB)
+
+#
+# Make targets
+#
+
+all: report
+
+test_triangle: $(SOURCE) $(TEST)
+	$(CC) $(CFLAGS) $(SOURCE) $(TEST) $(LDFLAGS) -o $@
+
+test: test_triangle
+	./test_triangle
+
+report: $(MUTATION_DB)
+	$(DEXTOOL) mutate report $(MFLAGS) \
+			--section summary \
+			--section alive \
+			--section killed \
+			--style html
+
+$(MUTATION_DB): $(SOURCE) $(TEST)
+	$(DEXTOOL) mutate analyze $(MFLAGS) \
+			--in $(SOURCE) \
+			-- $(CFLAGS)
+	$(DEXTOOL) mutate test $(MFLAGS) \
+			--build-cmd $(MAKEFILE_DIR)/build.sh \
+			--test-cmd $(MAKEFILE_DIR)/test.sh \
+			--test-timeout 1000
 
 clean:
-	rm -f triangle_test
+	rm -rf \
+		test_triangle \
+		$(MUTATION_DB) \
+		$(MUTATION_REPORT)

--- a/plugin/mutate/examples/triangle/build.sh
+++ b/plugin/mutate/examples/triangle/build.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e
-make clean
-make all
+make test_triangle


### PR DESCRIPTION
Makefile now also tracks dependencies to source code and restarts mutation
analysis accordingly.