### PR TITLE
dextool: improve trace logging of what compiler flags are passed on to

### DIFF
--- a/source/dextool/clang.d
+++ b/source/dextool/clang.d
@@ -45,8 +45,7 @@ Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compd
     import std.path : baseName;
     import std.typecons : Yes;
 
-    import cpptooling.analyzer.clang.check_parse_result : hasParseErrors,
-        logDiagnostic;
+    import cpptooling.analyzer.clang.check_parse_result : hasParseErrors, logDiagnostic;
     import cpptooling.analyzer.clang.context : ClangContext;
     import cpptooling.analyzer.clang.include_visitor : hasInclude;
 
@@ -89,7 +88,6 @@ Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname,
         const string[] flags, ref const CompileCommandFilter flag_filter) {
     import std.file : exists;
     import std.path : baseName;
-    import std.string : join;
 
     import dextool.compilation_db : appendOrError;
 
@@ -97,8 +95,8 @@ Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname,
 
     auto db_search_result = compdb.appendOrError(flags, fname, flag_filter);
     if (!db_search_result.isNull) {
-        rval = SearchResult(db_search_result.cflags, db_search_result.absoluteFile);
-        logger.trace("Compiler flags: ", rval.cflags.join(" "));
+        rval = SearchResult(db_search_result.flags, db_search_result.absoluteFile);
+        logger.trace(rval.flags);
         return rval;
     }
 
@@ -127,7 +125,7 @@ Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname,
 
     rval = SearchResult(flags ~ sres.derived.parseFlag(flag_filter), p);
     // the user may want to see the flags but usually uninterested
-    logger.trace("Compiler flags: ", rval.cflags.join(" "));
+    logger.trace(rval.flags);
 
     return rval;
 }

--- a/source/dextool/compilation_db/user_filerange.d
+++ b/source/dextool/compilation_db/user_filerange.d
@@ -42,11 +42,13 @@ struct UserFileRange {
         }
     }
 
-    const RangeOver kind;
-    CompileCommandDB db;
-    string[] inFiles;
-    string[] cflags;
-    const CompileCommandFilter ccFilter;
+    private {
+        const RangeOver kind;
+        CompileCommandDB db;
+        string[] inFiles;
+        string[] cflags;
+        const CompileCommandFilter ccFilter;
+    }
 
     Nullable!SearchResult front() {
         assert(!empty, "Can't get front of an empty range");
@@ -67,6 +69,8 @@ struct UserFileRange {
             curr.flags.cflags = cflags ~ curr.flags.cflags;
             break;
         }
+
+        logger.trace(!curr.isNull, curr.flags);
 
         return curr;
     }


### PR DESCRIPTION
clang when parsing source code.