### PR TITLE
mutate: (dcr/sdl) reduce generated mutants that trigger undefined

### DIFF
--- a/plugin/mutate/doc/design/mutations.md
+++ b/plugin/mutate/doc/design/mutations.md
@@ -395,6 +395,18 @@ The branch is deleted.
 
 Thus `false` is equivalent to statement deletion of the branch content.
 
+# SPC-mutation_dcr_bool_func
+partof: SPC-mutation_dcr
+###
+
+TODO: add req.
+
+## Why?
+
+The intention of DCR is to test that the test suite verify logical expressions.
+It is assumed that a function that returns bool is used in logical expressions in *some* way.
+This use should be verified by the test suite.
+
 # SPC-mutations_statement_del
 partof: REQ-mutations
 ###

--- a/plugin/mutate/test/mutate_dcc.d
+++ b/plugin/mutate/test/mutate_dcc.d
@@ -11,7 +11,7 @@ import dextool_test.utility;
 
 // dfmt off
 
-@("shall produce 2 predicate mutations")
+@(testId ~ "shall produce 2 predicate mutations")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -27,7 +27,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 4 predicate mutations")
+@(testId ~ "shall produce 4 predicate mutations")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -43,7 +43,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 4 predicate mutations")
+@(testId ~ "shall produce 4 predicate mutations")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -61,7 +61,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 2 predicate mutations for an expression of multiple clauses")
+@(testId ~ "shall produce 2 predicate mutations for an expression of multiple clauses")
 @Values("dcc_dc_ifstmt3.cpp", "dcc_dc_stmt3.cpp")
 unittest {
     mixin(envSetup(globalTestdir, No.setupEnv));
@@ -81,7 +81,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 6 clause mutations")
+@(testId ~ "shall produce 6 clause mutations")
 @Values("dcc_cc_ifstmt1.cpp", "dcc_cc_stmt1.cpp")
 unittest {
     mixin(envSetup(globalTestdir, No.setupEnv));
@@ -115,7 +115,7 @@ unittest {
     r.stdout.joiner.count("'x > 2'").shouldEqual(2);
 }
 
-@("shall produce 4 switch bomb mutations")
+@(testId ~ "shall produce 4 switch bomb mutations")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -133,7 +133,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 4 switch deletion mutations")
+@(testId ~ "shall produce 4 switch deletion mutations")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -157,7 +157,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 1 DCC mutant in C when the input is a C file")
+@(testId ~ "shall produce 1 DCC mutant in C when the input is a C file")
 unittest {
     mixin(EnvSetup(globalTestdir));
     makeDextoolAnalyze(testEnv)
@@ -173,7 +173,7 @@ unittest {
     ]).shouldBeIn(r.stdout);
 }
 
-@("shall produce 6 predicate and 8 clause mutations for an expression of multiple clauses of C code")
+@(testId ~ "shall produce 6 predicate and 8 clause mutations for an expression of multiple clauses of C code")
 unittest {
     mixin(EnvSetup(globalTestdir));
 
@@ -203,4 +203,21 @@ unittest {
         "from 'x == TRUE' to '1'",
         "from 'x == TRUE' to '0'",
     ]).shouldBeIn(r.stdout);
+}
+
+@("shall produce 2 predicate mutants for the bool function")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+
+    makeDextoolAnalyze(testEnv)
+        .addInputArg(testData ~ "dcr_bool_func.cpp")
+        .run;
+    auto r = makeDextool(testEnv)
+        .addArg(["test"])
+        .addArg(["--mutant", "dcr"])
+        .run;
+    testAnyOrder!SubStr([
+    "from 'fun(x)' to 'true'",
+    "from 'fun(x)' to 'false'",
+                        ]).shouldBeIn(r.stdout);
 }

--- a/plugin/mutate/test/mutate_stmt_deletion.d
+++ b/plugin/mutate/test/mutate_stmt_deletion.d
@@ -84,7 +84,9 @@ unittest {
         "'wun(calc(6))' to ''",
         "'calc(7)' to ''",
         "'calc(8)' to ''",
-        "'calc(10)' to ''",
-        "'calc(11)' to ''",
     ]).shouldBeIn(r.stdout);
+    //TODO: maybe these should be deletable too? But it would require forward
+    //looking.
+        //"'calc(10)' to ''",
+        //"'calc(11)' to ''",
 }

--- a/plugin/mutate/testdata/dcr_bool_func.cpp
+++ b/plugin/mutate/testdata/dcr_bool_func.cpp
@@ -1,0 +1,7 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2018
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+
+bool fun(int x);
+
+bool wun(int x) { return fun(x); }


### PR DESCRIPTION
behavior by
 * sdl. stop deleting call expressions inside return statements.
 * dcr. return true/false for bool functions.