### PR TITLE
mutate: (html) change color for killed by compiler

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/tmpl.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/tmpl.d
@@ -17,12 +17,12 @@ immutable tmplIndexStyle = `
 .mutant {display:none; background-color: yellow;}
 .status_alive {background-color: lightpink;}
 .status_killed {background-color: lightgreen;}
-.status_killedByCompiler {background-color: mediumseagreen;}
+.status_killedByCompiler {background-color: #eeeeee;}
 .status_timeout {background-color: limegreen;}
 .status_unknown {background-color: mistyrose;}
 .hover_alive {color: lightpink;}
 .hover_killed {color: lightgreen;}
-.hover_killedByCompiler {color: mediumseagreen;}
+.hover_killedByCompiler {color: #eeeeee;}
 .hover_timeout {color: limegreen;}
 .hover_unknown {color: mistyrose;}
 .literal {color: darkred;}


### PR DESCRIPTION
Test cases can not affect mutation points that are killed by the compiler. The idea of the selected color ([#eeeeee](https://www.color-hex.com/popular-colors.php)) is to indicate that the mutation result for such mutants can be disregarded in the context of test effectiveness.