### PR TITLE
mutate: fixup for lcr/lcrb/aor

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/visitor.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/visitor.d
@@ -102,23 +102,23 @@ VisitorResult makeRootVisitor(FilesysIO fio, ValidateLoc val_loc_) {
         return lcrMutations(k).op;
     };
     rval.transf.binaryOpExprCallback ~= (OpKind k) { return lcrMutations(k).expr; };
-    rval.transf.binaryOpRhsCallback ~= (OpKind, OpTypeInfo) => lcrRhsMutations;
-    rval.transf.binaryOpLhsCallback ~= (OpKind, OpTypeInfo) => lcrLhsMutations;
+    rval.transf.binaryOpRhsCallback ~= (OpKind k, OpTypeInfo) => lcrRhsMutations(k);
+    rval.transf.binaryOpLhsCallback ~= (OpKind k, OpTypeInfo) => lcrLhsMutations(k);
 
     rval.transf.binaryOpOpCallback ~= (OpKind k, OpTypeInfo) {
         return lcrbMutations(k);
     };
     rval.transf.assignOpOpCallback ~= (OpKind k) { return lcrbAssignMutations(k); };
-    rval.transf.binaryOpRhsCallback ~= (OpKind, OpTypeInfo) => lcrbRhsMutations;
-    rval.transf.binaryOpLhsCallback ~= (OpKind, OpTypeInfo) => lcrbLhsMutations;
+    rval.transf.binaryOpRhsCallback ~= (OpKind k, OpTypeInfo) => lcrbRhsMutations(k);
+    rval.transf.binaryOpLhsCallback ~= (OpKind k, OpTypeInfo) => lcrbLhsMutations(k);
 
     rval.transf.assignOpOpCallback ~= (OpKind k) { return aorAssignMutations(k); };
     rval.transf.binaryOpOpCallback ~= (OpKind k, OpTypeInfo) {
         return aorMutations(k);
     };
     rval.transf.assignOpOpCallback ~= (OpKind k) { return aorAssignMutations(k); };
-    rval.transf.binaryOpRhsCallback ~= (OpKind, OpTypeInfo) => aorRhsMutations;
-    rval.transf.binaryOpLhsCallback ~= (OpKind, OpTypeInfo) => aorLhsMutations;
+    rval.transf.binaryOpRhsCallback ~= (OpKind k, OpTypeInfo) => aorRhsMutations(k);
+    rval.transf.binaryOpLhsCallback ~= (OpKind k, OpTypeInfo) => aorLhsMutations(k);
 
     rval.transf.binaryOpOpCallback ~= (OpKind k, OpTypeInfo tyi) {
         if (k in isRor)

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/aor.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/aor.d
@@ -34,12 +34,12 @@ Mutation.Kind[] aorAssignMutations(OpKind k) @safe pure nothrow {
             Mutation.Kind.aorRhs, Mutation.Kind.aorLhs)).array;
 }
 
-auto aorLhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.aorRhs];
+auto aorLhsMutations(OpKind k) @safe pure nothrow {
+    return k in isAor ? [Mutation.Kind.aorLhs] : null;
 }
 
-auto aorRhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.aorLhs];
+auto aorRhsMutations(OpKind k) @safe pure nothrow {
+    return k in isAor ? [Mutation.Kind.aorRhs] : null;
 }
 
 immutable Mutation.Kind[OpKind] isAor;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcr.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcr.d
@@ -32,12 +32,12 @@ auto lcrMutations(OpKind k) @safe pure nothrow {
     return rval;
 }
 
-auto lcrLhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.lcrRhs];
+auto lcrLhsMutations(OpKind k) @safe pure nothrow {
+    return k in isLcr ? [Mutation.Kind.lcrLhs] : null;
 }
 
-auto lcrRhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.lcrLhs];
+auto lcrRhsMutations(OpKind k) @safe pure nothrow {
+    return k in isLcr ? [Mutation.Kind.lcrRhs] : null;
 }
 
 immutable Mutation.Kind[OpKind] isLcr;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcrb.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcrb.d
@@ -24,12 +24,12 @@ auto lcrbMutations(OpKind k) @safe pure nothrow {
     return null;
 }
 
-auto lcrbLhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.lcrbRhs];
+auto lcrbLhsMutations(OpKind k) @safe pure nothrow {
+    return k in isLcrb ? [Mutation.Kind.lcrbLhs] : null;
 }
 
-auto lcrbRhsMutations() @safe pure nothrow {
-    return [Mutation.Kind.lcrbLhs];
+auto lcrbRhsMutations(OpKind k) @safe pure nothrow {
+    return k in isLcrb ? [Mutation.Kind.lcrbRhs] : null;
 }
 
 auto lcrbAssignMutations(OpKind k) @safe pure nothrow {

--- a/plugin/mutate/test/generate_mutant.d
+++ b/plugin/mutate/test/generate_mutant.d
@@ -29,6 +29,6 @@ unittest {
         .run;
 
     testAnyOrder!SubStr([
-        "-abs_dextool(x > 3)",
+        "-abs_dextool(x)",
     ]).shouldBeIn(readOutput(testEnv, "report_one_ror_mutation_point.cpp"));
 }

--- a/plugin/mutate/test/test_mutant_tester.d
+++ b/plugin/mutate/test/test_mutant_tester.d
@@ -723,7 +723,7 @@ class ShallKeepTheTestCaseResultsLinkedToMutantsWhenReAnalyzing : DatabaseFixtur
                 5.dur!"msecs", [TestCase("tc_1")]);
         // verify pre-condition that test cases exist in the DB
         auto r0 = makeDextoolReport(testEnv, testData.dirName).addArg(["--section", "tc_stat"]).run;
-        testConsecutiveSparseOrder!SubStr(["| 100        | 3     | tc_1     |"]).shouldBeIn(
+        testConsecutiveSparseOrder!SubStr(["| 100        | 2     | tc_1     |"]).shouldBeIn(
                 r0.stdout);
 
         // Act
@@ -731,7 +731,7 @@ class ShallKeepTheTestCaseResultsLinkedToMutantsWhenReAnalyzing : DatabaseFixtur
 
         // Assert that the test cases are still their
         auto r1 = makeDextoolReport(testEnv, testData.dirName).addArg(["--section", "tc_stat"]).run;
-        testConsecutiveSparseOrder!SubStr(["| 100        | 3     | tc_1     |"]).shouldBeIn(
+        testConsecutiveSparseOrder!SubStr(["| 100        | 2     | tc_1     |"]).shouldBeIn(
                 r1.stdout);
     }
 }

--- a/plugin/mutate/test/test_report.d
+++ b/plugin/mutate/test/test_report.d
@@ -65,13 +65,13 @@ unittest {
     testConsecutiveSparseOrder!SubStr([
         "# Mutation Type",
         "## Mutants",
-        "| From  | To | File Line:Column                                                          | ID | Status |",
-        "|-------|----|---------------------------------------------------------------------------|----|--------|",
-        "| `x >` | `` | build/plugin/mutate/plugin_testdata/report_one_ror_mutation_point.cpp 6:9 | 1  | alive  |",
+        "| From | To   | File Line:Column                                                           | ID | Status |",
+        "|------|------|----------------------------------------------------------------------------|----|--------|",
+        "| `>`  | `>=` | build/plugin/mutate/plugin_testdata/report_one_ror_mutation_point.cpp 6:11 | 1  | alive  |",
         "## Alive Mutation Statistics",
-        "| Percentage | Count | From  | To |",
-        "|------------|-------|-------|----|",
-        "| 100        | 3     | `x >` | `` |",
+        "| Percentage | Count | From | To   |",
+        "|------------|-------|------|------|",
+        "| 100        | 2     | `>`  | `>=` |",
         "## Summary",
         "Mutation execution time:",
         "Untested:",
@@ -167,9 +167,9 @@ unittest {
 
     testConsecutiveSparseOrder!SubStr([
         `"ID","Kind","Description","Location","Comment"`,
-        `"14","dcr","'var1_long_text >5' to 'true'","build/plugin/mutate/plugin_testdata/report_as_csv.cpp:7:9",""`,
-        `"15","dcr","'var1_long_text >5' to 'false'","build/plugin/mutate/plugin_testdata/report_as_csv.cpp:7:9",""`,
-        `"33","dcr","'case 2:`,
+        `"8","dcr","'var1_long_text >5' to 'true'","build/plugin/mutate/plugin_testdata/report_as_csv.cpp:7:9",""`,
+        `"9","dcr","'var1_long_text >5' to 'false'","build/plugin/mutate/plugin_testdata/report_as_csv.cpp:7:9",""`,
+        `"27","dcr","'case 2:`,
         `        return true;' to ''","build/plugin/mutate/plugin_testdata/report_as_csv.cpp:11:5",""`,
     ]).shouldBeIn(r.stdout);
 }
@@ -210,9 +210,9 @@ unittest {
     testConsecutiveSparseOrder!SubStr([
         "| Percentage | Count | TestCase | Location |",
         "|------------|-------|----------|----------|",
-        "| 75         | 6     | tc_2     |          |",
-        "| 37.5       | 3     | tc_3     |          |",
-        "| 37.5       | 3     | tc_1     |          |",
+        "| 80         | 4     | tc_2     |          |",
+        "| 40         | 2     | tc_3     |          |",
+        "| 40         | 2     | tc_1     |          |",
     ]).shouldBeIn(r.stdout);
 }
 
@@ -281,8 +281,8 @@ unittest {
     testConsecutiveSparseOrder!SubStr([
         "| Percentage | Count | TestCase |",
         "|------------|-------|----------|",
-        "| 37.5       | 3     | tc_1     |",
-        "| 37.5       | 3     | tc_3     |",
+        "| 40         | 2     | tc_1     |",
+        "| 40         | 2     | tc_3     |",
     ]).shouldBeIn(r.stdout);
 }
 
@@ -418,23 +418,23 @@ class ShallReportMutationScoreAdjustedByNoMut : LinesWithNoMut {
 
         // assert
         testConsecutiveSparseOrder!SubStr([
-            "Score:   0.545",
-            "Alive:   14",
-            "Killed:  8",
+            "Score:   0.808",
+            "Alive:   15",
+            "Killed:  11",
             "Timeout: 0",
-            "Total:   22",
+            "Total:   26",
             "Killed by compiler: 0",
-            "Suppressed (nomut): 4 (0.182",
+            "Suppressed (nomut): 10 (0.385",
         ]).shouldBeIn(plain.stdout);
 
         testConsecutiveSparseOrder!SubStr([
-            "Score:   0.545",
-            "Alive:   14",
-            "Killed:  8",
+            "Score:   0.808",
+            "Alive:   15",
+            "Killed:  11",
             "Timeout: 0",
-            "Total:   22",
+            "Total:   26",
             "Killed by compiler: 0",
-            "Suppressed (nomut): 4 (0.182",
+            "Suppressed (nomut): 10 (0.385",
         ]).shouldBeIn(markdown.stdout);
     }
 }


### PR DESCRIPTION
The latest changes ended up mutating expressions that isn't strictly
connected to the intended operators.