### PR TITLE
mutate: allow the user to override the compiler from the

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -78,6 +78,7 @@ struct Analyzer {
         this.before_files = db.getFiles.setFromList;
         this.val_loc = val_loc;
         this.fio = fio;
+        this.conf = conf;
         this.cache = new Cache;
 
         db.removeAllFiles;

--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -72,11 +72,18 @@ struct ConfigCompileDb {
 
 /// Settings for the compiler
 struct ConfigCompiler {
+    import dextool.compilation_db : SystemCompiler = Compiler;
+
     /// Additional flags the user wants to add besides those that are in the compile_commands.json.
     string[] extraFlags;
 
     /// True requires system includes to be passed on to the compiler via -I
     bool forceSystemIncludes;
+
+    /// Deduce compiler flags from this compiler and not the one in the
+    /// supplied compilation database.  / This is needed when the one specified
+    /// in the DB has e.g. a c++ stdlib that is not compatible with clang.
+    SystemCompiler useCompilerSystemIncludes;
 }
 
 /// Settings for mutation testing

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -73,7 +73,7 @@ struct ArgParser {
         import dextool.compilation_db : defaultCompilerFlagFilter, CompileCommandFilter;
 
         ArgParser r;
-        r.compileDb.flagFilter = CompileCommandFilter(defaultCompilerFlagFilter, 1);
+        r.compileDb.flagFilter = CompileCommandFilter(defaultCompilerFlagFilter, 0);
         return r;
     }
 
@@ -122,6 +122,10 @@ struct ArgParser {
         app.put(format("# filter = [%(%s, %)]", compileDb.flagFilter.filter));
         app.put("# compiler arguments to skip from the beginning. Needed when the first argument is NOT a compiler but rather a wrapper");
         app.put(format("# skip_compiler_args = %s", compileDb.flagFilter.skipCompilerArgs));
+        app.put(
+                "# use this compilers system includes instead of the one used in the compile_commands.json");
+        app.put(format(`# use_compiler_system_includes = "%s"`, compiler.useCompilerSystemIncludes.length == 0
+                ? "/path/to/c++" : compiler.useCompilerSystemIncludes.value));
         app.put(null);
 
         app.put("[mutant_test]");
@@ -445,7 +449,7 @@ void updateCompileDb(ref ConfigCompileDb db, string[] compile_dbs) {
  * It must be enough information that the user can adjust `--out` and `--restrict`.
  */
 void printFileAnalyzeHelp(ref ArgParser ap) @safe {
-    logger.infof("Reading compilation database:\n%(%s\n%)", ap.compileDb.dbs);
+    logger.infof("Reading compilation database:\n%-(%s\n%)", ap.compileDb.dbs);
 
     logger.info(
             "Analyze and mutation of files will only be done on those inside this directory root");
@@ -527,6 +531,9 @@ void loadConfig(ref ArgParser rval) @trusted {
     };
     callbacks["compiler.force_system_includes"] = (ref ArgParser c, ref TOMLValue v) {
         c.compiler.forceSystemIncludes = v == true;
+    };
+    callbacks["compiler.use_compiler_system_includes"] = (ref ArgParser c, ref TOMLValue v) {
+        c.compiler.useCompilerSystemIncludes = v.str;
     };
 
     callbacks["mutant_test.test_cmd"] = (ref ArgParser c, ref TOMLValue v) {

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
@@ -91,8 +91,8 @@ struct DataAccess {
                 conf.workArea.outputDirectory, conf.mutationTest.dryRun);
         auto fe_validate = new FrontendValidateLoc(conf.workArea.restrictDir,
                 conf.workArea.outputDirectory);
-        auto frange = UserFileRange(fusedCompileDb, conf.data.inFiles,
-                conf.compiler.extraFlags, conf.compileDb.flagFilter);
+        auto frange = UserFileRange(fusedCompileDb, conf.data.inFiles, conf.compiler.extraFlags,
+                conf.compileDb.flagFilter, conf.compiler.useCompilerSystemIncludes);
 
         return DataAccess(Database.make(conf.db, conf.mutationTest.mutationOrder),
                 fe_io, fe_validate, frange, fusedCompileDb);

--- a/plugin/mutate/test/test_config.d
+++ b/plugin/mutate/test/test_config.d
@@ -53,3 +53,20 @@ unittest {
     testConsecutiveSparseOrder!SubStr(["uc3, Resetting Mocks, VerifyAndClear.*"]).shouldBeIn(
             r.stdout);
 }
+
+@("shall use the user specified compiler to determine system includes")
+unittest {
+    import std.path : buildPath;
+
+    mixin(EnvSetup(globalTestdir));
+    dirContentCopy(buildPath(testData.toString, "config",
+            "specify_sys_compiler"), testEnv.outdir.toString);
+    File((testEnv.outdir ~ ".dextool_mutate.toml").toString, "a").writefln(
+            `use_compiler_system_includes = "%s/fake_cc.d"`, testEnv.outdir.toString);
+
+    auto r = makeDextoolAnalyze(testEnv).addArg(["-c", (testEnv.outdir ~ ".dextool_mutate.toml").toString])
+        .addArg(["--compile-db", (testEnv.outdir ~ "compile_commands.json").toString]).run;
+
+    testConsecutiveSparseOrder!SubStr(["trace: Compiler flags: -xc++ -isystem /foo/bar"]).shouldBeIn(
+            r.stdout);
+}

--- a/plugin/mutate/testdata/config/specify_sys_compiler/.dextool_mutate.toml
+++ b/plugin/mutate/testdata/config/specify_sys_compiler/.dextool_mutate.toml
@@ -1,0 +1,18 @@
+[workarea]
+root = "."
+restrict = []
+
+[database]
+db = "dextool_mutate.sqlite3"
+
+[compile_commands]
+search_paths = ["./compile_commands.json"]
+
+[mutant_test]
+test_cmd = "test.sh"
+test_cmd_timeout = 1000
+build_cmd = "compile.sh"
+
+[compiler]
+extra_flags = [ "-xc++" ]
+

--- a/plugin/mutate/testdata/config/specify_sys_compiler/compile_commands.json
+++ b/plugin/mutate/testdata/config/specify_sys_compiler/compile_commands.json
@@ -1,0 +1,7 @@
+[
+    {
+        "directory": ".",
+        "arguments": ["g++", "-c", "empty.cpp", "-o", "empty.o"],
+        "file": "empty.cpp"
+    }
+]

--- a/plugin/mutate/testdata/config/specify_sys_compiler/fake_cc.d
+++ b/plugin/mutate/testdata/config/specify_sys_compiler/fake_cc.d
@@ -1,0 +1,12 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "fake_cc"
++/
+
+import std.stdio : writeln;
+
+void main(string[] args) {
+    writeln("#include <...> search starts here:");
+    writeln("/foo/bar");
+    writeln("End of search list.");
+}

--- a/source/dextool/clang.d
+++ b/source/dextool/clang.d
@@ -15,7 +15,7 @@ import std.typecons : Nullable;
 import logger = std.experimental.logger;
 
 import dextool.compilation_db : SearchResult, CompileCommandDB,
-    CompileCommandFilter, CompileCommand, parseFlag;
+    CompileCommandFilter, CompileCommand, parseFlag, DbCompiler = Compiler;
 import dextool.type : FileName, AbsolutePath;
 
 @safe:
@@ -38,8 +38,9 @@ private struct IncludeResult {
  *
  * Returns: The first CompileCommand object which _probably_ has the flags needed to parse fname.
  */
-Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compdb,
-        FileName fname, ref const CompileCommandFilter flag_filter, const string[] extra_flags) @trusted {
+Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compdb, FileName fname,
+        ref const CompileCommandFilter flag_filter, const string[] extra_flags,
+        const DbCompiler user_compiler = DbCompiler.init) @trusted {
     import std.algorithm : filter;
     import std.file : exists;
     import std.path : baseName;
@@ -60,7 +61,7 @@ Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compd
     Nullable!IncludeResult r;
 
     foreach (entry; compdb.filter!(a => exists(a.absoluteFile))) {
-        auto flags = extra_flags ~ entry.parseFlag(flag_filter);
+        auto flags = extra_flags ~ entry.parseFlag(flag_filter, user_compiler);
         auto translation_unit = ctx.makeTranslationUnit(entry.absoluteFile, flags);
 
         if (translation_unit.hasParseErrors) {
@@ -84,8 +85,9 @@ Nullable!IncludeResult findCompileCommandFromIncludes(ref CompileCommandDB compd
 }
 
 /// Find flags for fname by searching in the compilation DB.
-Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname,
-        const string[] flags, ref const CompileCommandFilter flag_filter) {
+Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname, const string[] flags,
+        ref const CompileCommandFilter flag_filter, const DbCompiler user_compiler = DbCompiler
+        .init) {
     import std.file : exists;
     import std.path : baseName;
 
@@ -123,7 +125,7 @@ Nullable!SearchResult findFlags(ref CompileCommandDB compdb, FileName fname,
     logger.warningf(`Using compiler flags derived from '%s' because it has an '#include' for '%s'`,
             sres.original.absoluteFile, sres.derived.absoluteFile);
 
-    rval = SearchResult(flags ~ sres.derived.parseFlag(flag_filter), p);
+    rval = SearchResult(flags ~ sres.derived.parseFlag(flag_filter, user_compiler), p);
     // the user may want to see the flags but usually uninterested
     logger.trace(rval.flags);
 


### PR DESCRIPTION
compile_commands.json.

This is useful for the analyze phase when the C++ standard library isn't
compatible with the clang frontend. Such is the case for e.g. gcc-4.X