### PR TITLE
mutate: nomut is not always show in the html report

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
@@ -179,6 +179,25 @@ void makeSrcMetadataView(ref Microrm db) {
             mutationPointTable, filesTable));
 }
 
+// Reconstruct the view in Microrm.
+@TableName(srcMetadataTable)
+struct SrcMetadataTbl {
+    @ColumnName("mut_id")
+    long mutationId;
+
+    @ColumnName("st_id")
+    long mutationStatusId;
+
+    @ColumnName("mp_id")
+    long mutationPointId;
+
+    @ColumnName("file_id")
+    long fileId;
+
+    @ColumnName("nomut")
+    long nomutCount;
+}
+
 @TableName(schemaVersionTable)
 struct VersionTbl {
     @ColumnName("version")

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
@@ -126,6 +126,7 @@ struct MutationStatus {
     Nullable!SysTime added;
 }
 
+// TODO: rename to LineMetaData.
 /// Metadata about a line in a file.
 struct LineMetadata {
     import dextool.set;
@@ -157,8 +158,36 @@ struct LineMetadata {
     }
 }
 
+// TODO: rename this to MutationMetaData.
 /// Attributes for a line.
 enum LineAttr {
     /// Suppress all alive mutants on the line.
     noMut
+}
+
+/// Metadata about a mutant.
+struct MutantMetaData {
+    import dextool.set;
+
+    MutationId id;
+    Set!LineAttr attrs;
+
+    alias attrs this;
+
+    this(MutationId id) {
+        this(id, LineAttr[].init);
+    }
+
+    this(MutationId id, LineAttr[] attrs) {
+        this.id = id;
+        this.attrs = setFromList(attrs);
+    }
+
+    void add(LineAttr v) {
+        attrs.add(v);
+    }
+
+    bool contains(LineAttr v) {
+        return attrs.contains(v);
+    }
 }


### PR DESCRIPTION
The reason is that a mutant that span multiple lines may have the NOMUT
comment on a line different from the where it starts. Thus the
optimization that where used which only store the NOMUT per line failed.

The solution is to query the database for each mutant and get the
metadata for it. The con is that this is a bit slower but it works.