### PR TITLE
mutate: make manual analyser command able to inform dextool of passed

### DIFF
--- a/plugin/mutate/test/fixtures.d
+++ b/plugin/mutate/test/fixtures.d
@@ -72,7 +72,7 @@ exit 1
         // the test -e test that the output file has been created
         return "#!/bin/bash
 set -e
-test -e $1 && echo 'Failed 42'
+test -e $1 && echo 'failed:Failed 42'
 ";
     }
 }


### PR DESCRIPTION
and failed tests. This makes it possible for dextool to detect all test
cases that exist in the test suite.