### PR TITLE
mutate: the user can't see the inner scroll bar because it is overlaped

### DIFF
--- a/plugin/mutate/view/source.js
+++ b/plugin/mutate/view/source.js
@@ -355,7 +355,7 @@ function get_closest_loc(target) {
 function on_window_resize() {
     var info_box = document.getElementById('info');
     var top = info_box.offsetTop - info_box.style.marginTop;
-    var left = window.innerWidth - info_box.clientWidth;
+    var left = window.innerWidth - info_box.clientWidth - 30;
     info_box.style.left = left + "px";
     info_box.style.top = top + "px";
 }


### PR DESCRIPTION
with the outer scroll bar.