### PR TITLE
mutate: improve handling of timeout mutants

### DIFF
--- a/plugin/mutate/doc/design/figures/test_mutant_fsm.pu
+++ b/plugin/mutate/doc/design/figures/test_mutant_fsm.pu
@@ -1,0 +1,45 @@
+@startuml
+hide empty description
+
+[*] -> Initialize
+
+Initialize -> SanityCheck
+
+SanityCheck --> Error : failed
+SanityCheck -> PreCompileSut
+
+PreCompileSut --> Error : failed
+PreCompileSut -> UpdateAndResetAliveMutants
+
+UpdateAndResetAliveMutants -> ResetOldMutants
+
+ResetOldMutants --> CheckMutantsLeft
+
+UpdateTimeout --> CleanupTempDirs
+
+CleanupTempDirs --> NextMutant
+
+CheckMutantsLeft --> Done : allTested
+CheckMutantsLeft --> MeasureTestSuite
+
+MeasureTestSuite --> Error : unreliable
+MeasureTestSuite --> UpdateTimeout
+
+NextMutant --> CheckTimeout : allTested
+NextMutant --> PreMutationTest
+
+PreMutationTest --> MutationTest
+
+MutationTest --> HandleTestResult : next
+MutationTest --> Error : error
+MutationTest --> MutationTest
+
+HandleTestResult --> UpdateTimeout
+
+CheckTimeout --> Done : unchanged
+CheckTimeout --> UpdateTimeout
+
+Done --> Done
+
+Error --> Error
+@enduml

--- a/plugin/mutate/doc/design/figures/timeout_mutant.pu
+++ b/plugin/mutate/doc/design/figures/timeout_mutant.pu
@@ -3,13 +3,13 @@
 start
 :get context from db;
 if (state is) then (init)
-    :add mutant to worklist;
-    :set mutant status to timeout;
+    if (status is) then (timeout)
+        :add mutant to worklist;
+    endif
+    :set mutant status;
 elseif (state is) then (running)
     if (local_iter == db_iter) then (yes)
         :set mutant status;
-    else
-        :local_iter = db_iter;
     endif
 endif
 stop

--- a/plugin/mutate/doc/design/figures/timeout_mutant.pu
+++ b/plugin/mutate/doc/design/figures/timeout_mutant.pu
@@ -1,0 +1,42 @@
+@startuml
+'setting a mutant status
+start
+:get context from db;
+if (state is) then (init)
+    :add mutant to worklist;
+    :set mutant status to timeout;
+elseif (state is) then (running)
+    if (local_iter == db_iter) then (yes)
+        :set mutant status;
+    else
+        :local_iter = db_iter;
+    endif
+endif
+stop
+@enduml
+
+@startuml
+hide empty description
+
+Init: **init**
+Running: **running**
+Done: **done**
+Done: set state to done
+Purge: remove mutants in worklist
+Purge: with a state other than
+Purge: timeout
+ResetWorkList: set mutants in worklist
+ResetWorkList: to unknown
+UpdateCtx: set iter+=1
+UpdateCtx: set worklist_cnt=count(worklist)
+
+[*] -> Init
+Init -> ResetWorkList : evAllStatus
+ResetWorkList --> UpdateCtx
+UpdateCtx --> Running
+Running -> Purge : evAllStatus
+Purge --> ResetWorkList : evChange
+Purge -> ClearWorkList : evSame
+ClearWorkList -> Done
+Done --> [*]
+@enduml

--- a/plugin/mutate/doc/design/test_mutant/basis.md
+++ b/plugin/mutate/doc/design/test_mutant/basis.md
@@ -24,14 +24,17 @@ partof: SPC-test_mutant
 
 The plugin shall terminate a test suite when it reached the *timeout*.
 
-The plugin shall *adjust* the timeout when there are no mutants in the state *unknown* and there are at least one mutant in the state *timeout*.
+The plugin shall *adjust* the timeout when there are no mutants in the state
+*unknown* and there are at least one mutant in the state *timeout*.
 
-TODO: further refine the requirements. The intent is what is described in the below algorithm.
+TODO: further refine the requirements. The intent is what is described in the
+below algorithm.
 
 ### Mutation Timeout Reduction Algorithm
 
-The purpose is to progressively increase the timeout until the pool of mutants tagged as *timeout* stop being reduced.
-It is to give the test suite enough time to *finish* and thus *fail* to detect a mutant.
+The purpose is to progressively increase the timeout until the pool of mutants
+tagged as *timeout* stop being reduced.  It is to give the test suite enough
+time to *finish* and thus *fail* to detect a mutant.
 
 $timeout(R, n) = R \times
 \begin{cases}
@@ -57,12 +60,20 @@ Pseudo-code:
 
 #### Mathematical Properties of Timeout Increase
 
-It is important to understand the assumptions the algorithm try to handle. The assumptions have not been verified.
+It is important to understand the assumptions the algorithm try to handle. The
+assumptions have not been verified.
  * a timeout is a sign that the test suite has gone into an infinite loop
- * a timeout is counted as the mutation being killed because it is an observable effect. Semantic difference
- * the runtime of the test suite when it passes (normal runtime) is the *max* it takes to run the test suite because it stops early when it finds a defect (mutant)
- * the normal runtime will fluctuate when a mutant fails. By choosing a timeout of 200% of the normal runtime these fluctuations are covered
- * by increasing the mutation timeout to 1000% the second iteration it is such a sharp increase that it should with a wide margin catch those cases there is a test suite that takes *markedly* longer to finish for *some* mutations but still result in the mutant being killed
+ * a timeout is counted as the mutation being killed because it is an
+   observable effect. Semantic difference
+ * the runtime of the test suite when it passes (normal runtime) is the *max*
+   it takes to run the test suite because it stops early when it finds a defect
+   (mutant)
+ * the normal runtime will fluctuate when a mutant fails. By choosing a timeout
+   of 200% of the normal runtime these fluctuations are covered
+ * by increasing the mutation timeout to 1000% the second iteration it is such
+   a sharp increase that it should with a wide margin catch those cases there
+   is a test suite that takes *markedly* longer to finish for *some* mutations
+   but still result in the mutant being killed
 
 The desired mathematical property of the algorithm for increasing the mutation
 testing is a sharp increase in the mutation time the second iteration. After
@@ -133,36 +144,60 @@ Description of the events used in figure \ref{fig-timeout-mutant-fsm}:
 
 The status of a mutant is update as described in figure \ref{fig-timeout-mutant-act}.
 
-![Setting the status of a mutant](figures/timeout_mutant.eps){#fig-timeout-mutant-act}
+![Setting the status of a mutant](figures/timeout_mutant.eps){#fig-timeout-mutant-act height=40%}
 
 # REQ-unstable_test_suite
 partof: REQ-test_mutant
 ###
 
-The users test suite is unreliable. Because of different reasons it can sometimes fail when testing a mutant. When the test suite fails the plugin should try, as instructed by the user, to apply a re-test strategy to achieve as accurate data as possible.
+The users test suite is unreliable. Because of different reasons it can
+sometimes fail when testing a mutant. When the test suite fails the plugin
+should try, as instructed by the user, to apply a re-test strategy to achieve
+as accurate data as possible.
 
-In other words try to avoid writing erroneous or even wrong data which could result in a highly inaccurate report.
+In other words try to avoid writing erroneous or even wrong data which could
+result in a highly inaccurate report.
 
 Failing means either or a combination of these:
-1. the test suite is unable to state passed/failed by setting the exist status. This can happen if e.g. the test suite relies on external hardware that sometimes lock up and need to be manually restored. If the status "passed" where written (via exit status 0) it would be a lie because maybe the tests would have killed it. In the same vein a "failed" would also be a lie because maybe the test wouldn't fail? It is thus unknown what the actual status is on the test suite. Would the test suite kill the mutant or not.
-2. the test suite fail in the middle of running test cases but one of the tests killed the mutant. The problem here occurs when the user wants to record what test cases killed the mutant. In this case the suite *could* exit with exit status 1 because it has proved that at least one test case kills the mutant **but** because the test suite started to produce incomprehensible errors in the middle dextool is unable to discern all the test cases that killed the mutant.
+1. the test suite is unable to state passed/failed by setting the exist status.
+   This can happen if e.g. the test suite relies on external hardware that
+   sometimes lock up and need to be manually restored. If the status "passed"
+   where written (via exit status 0) it would be a lie because maybe the tests
+   would have killed it. In the same vein a "failed" would also be a lie
+   because maybe the test wouldn't fail? It is thus unknown what the actual
+   status is on the test suite. Would the test suite kill the mutant or not.
+2. the test suite fail in the middle of running test cases but one of the tests
+   killed the mutant. The problem here occurs when the user wants to record
+   what test cases killed the mutant. In this case the suite *could* exit with
+   exit status 1 because it has proved that at least one test case kills the
+   mutant **but** because the test suite started to produce incomprehensible
+   errors in the middle dextool is unable to discern all the test cases that
+   killed the mutant.
 
 The two scenarios described will most likely require that two or more tools are provided to the user.
 
 ## TODO
 
-Impl a strategy for handling scenario 1) if needed. For now the control over the exit status is always in the users hand (!= 0 means killed) together with the "retest:" mean that the user probably have enough tools at hand.
+Impl a strategy for handling scenario 1) if needed. For now the control over
+the exit status is always in the users hand (!= 0 means killed) together with
+the "retest:" mean that the user probably have enough tools at hand.
 
 # SPC-retest_mutant_on_unstable_test_case
 partof: REQ-unstable_test_suite
 ###
 
-The plugin shall record *unknown* as the status of the mutant being tested when the *external test case analyser* writes "retest:" to stdout.
+The plugin shall record *unknown* as the status of the mutant being tested when
+the *external test case analyser* writes "retest:" to stdout.
 
-**Note**: This mean that it ignores the exist status from the test suite if it finds a "retest:".
+**Note**: This mean that it ignores the exist status from the test suite if it
+finds a "retest:".
 
 ## Rationale
 
-This makes it possible for a user to inform dextool that the mutant should be retested because the test suite started to become unstable when executing the test suite.
+This makes it possible for a user to inform dextool that the mutant should be
+retested because the test suite started to become unstable when executing the
+test suite.
 
-The user is free to use this or to ignore the instability because if the user chooses to **not** write "retest:" to stdout the exist status will be used to write the status of the mutant.
+The user is free to use this or to ignore the instability because if the user
+chooses to **not** write "retest:" to stdout the exist status will be used to
+write the status of the mutant.

--- a/plugin/mutate/doc/design/test_mutant/basis.md
+++ b/plugin/mutate/doc/design/test_mutant/basis.md
@@ -16,7 +16,12 @@ The implementation testing mutants should separate the drivers in three parts:
      * mutation timeout reduction algorithm
  * test a mutant
 
-## Drivers
+## Driver
+
+This is the state machine used in the test driver when the plugin is testing
+mutants in the database.
+
+![The test drivers FSM](figures/test_mutant_fsm.eps)
 
 # SPC-test_mutant_timeout
 partof: SPC-test_mutant

--- a/plugin/mutate/doc/metadata.yaml
+++ b/plugin/mutate/doc/metadata.yaml
@@ -8,4 +8,12 @@ language: en-US
 stylesheet: epub.css
 abstract: |
     The purpose of this plugin is to perform mutation testing of a _target_.
+numbersections: true
+links-as-notes: true
+colorlinks: true
+lof: true
+header-includes:
+  - \usepackage{graphicx}
+  - \usepackage{float}
+  - \usepackage{wrapfig}
 ...

--- a/plugin/mutate/doc/pandoc.d
+++ b/plugin/mutate/doc/pandoc.d
@@ -6,21 +6,21 @@
  * documentation for the Dextool mutation testing plugin.
  *
  * Dependent on the following packages (Ubuntu):
- * `sudo apt install texlive-bibtex-extra biber pandoc pandoc-citeproc`
+ * `sudo apt install texlive-bibtex-extra biber pandoc pandoc-citeproc texlive-font-utils latexmk`
  */
-
+import core.stdc.stdlib;
+import logger = std.experimental.logger;
 import std.algorithm;
 import std.array;
 import std.ascii;
 import std.conv;
+import std.exception : collectException;
 import std.file;
-import std.process;
 import std.path;
-import core.stdc.stdlib;
+import std.process;
 import std.range;
 import std.stdio;
 import std.string;
-import logger = std.experimental.logger;
 
 void main(string[] args) {
     const string root = getcwd();
@@ -29,6 +29,8 @@ void main(string[] args) {
     if (!exists(latex_dir)) {
         mkdir(latex_dir);
     }
+
+    prepareFigures(buildPath(root, "design", "figures"), buildPath(latex_dir, "figures"));
 
     chdir(latex_dir);
     scope (exit)
@@ -41,29 +43,17 @@ void main(string[] args) {
 
     auto dat = Pandoc(metadata, latex_template, biblio);
 
-    string[] design_chapters;
-    design_chapters ~= "use_cases.md";
-    design_chapters ~= "purpose.md";
-    design_chapters ~= "security.md";
-    design_chapters ~= "architecture.md";
-    design_chapters ~= "mutations.md";
-    design_chapters ~= "analyzer/analyzer.md";
-    design_chapters ~= "test_mutant/basis.md";
-    design_chapters ~= "usability/sanity_check.md";
-    design_chapters ~= "usability/report.md";
-    design_chapters ~= "future_work.md";
+    string[] chapters = [
+        "use_cases.md", "purpose.md", "security.md", "architecture.md",
+        "mutations.md", "analyzer/analyzer.md", "test_mutant/basis.md",
+        "usability/sanity_check.md", "usability/report.md", "future_work.md",
+    ];
 
-    // dfmt off
-    pandoc(
-        dat,
-        chain(design_chapters.map!(a => buildPath(root, "design", a)),
-              ["definitions.md", "abbrevations.md", "appendix.md", "references.md"].map!(a => buildPath(root, a))).array,
-        output);
-    // dfmt on
-}
-
-string home() {
-    return expandTilde("~");
+    pandoc(dat, chain(chapters.map!(a => buildPath(root, "design", a)),
+            [
+                "definitions.md", "abbrevations.md", "appendix.md",
+                "references.md"
+            ].map!(a => buildPath(root, a))).array, output);
 }
 
 struct Pandoc {
@@ -73,36 +63,60 @@ struct Pandoc {
 }
 
 void pandoc(Pandoc dat, string[] files, const string output) {
+    const outputTex = output ~ ".tex";
+    const biblio = buildPath(output.dirName, dat.biblio.baseName);
+    copy(dat.biblio, biblio);
+
     // dfmt off
     auto cmd = ["pandoc",
+         //"--pdf-engine", "xelatex",
          "--template", dat.latexTemplate,
-         "-f", "markdown_github+citations+yaml_metadata_block+tex_math_dollars+raw_tex+smart",
+         "-f", "markdown+smart+pipe_tables+raw_html+fenced_code_blocks+auto_identifiers+gfm_auto_identifiers+backtick_code_blocks+autolink_bare_uris+space_in_atx_header+strikeout+shortcut_reference_links+angle_brackets_escapable+lists_without_preceding_blankline+citations+yaml_metadata_block+tex_math_dollars+raw_tex+footnotes+header_attributes+link_attributes",
+         "-t", "latex",
          "--standalone",
          "--toc",
-         "--bibliography", dat.biblio,
+         "--bibliography", biblio,
          //"--biblio", dat.biblio,
          //"--biblatex", "-M", "biblio-style=numeric-comp",
          //"--csl", "chicago-author-date.csl",
          "--natbib", "-M", "biblio-style=unsrtnat", "-M", "biblio-title=heading=none",
-         //"--to", "latex",
-         //"-o", output ~ ".pdf",
-         "-o", output ~ ".latex",
+         "-o", outputTex,
          dat.metadata,
     ] ~ files;
     // dfmt on
 
     run(cmd);
-    // generates the aux
-    run(["pdflatex", output ~ ".latex"]);
-    // generate first pass of the resolution of references
-    try {
-        run(["bibtex", output ~ ".aux"]);
-    } catch (Exception e) {
-    }
+    run(["pdflatex", outputTex]);
+    run(["bibtex", outputTex.setExtension("aux")]).collectException;
+    run(["pdflatex", outputTex]);
+    run(["pdflatex", outputTex]);
+}
 
-    // continue resolving references. At least two times is needed.
-    run(["pdflatex", output ~ ".latex"]);
-    run(["pdflatex", output ~ ".latex"]);
+void prepareFigures(string src, string dest_dir) {
+    import std.algorithm : map, joiner;
+    import std.datetime : SysTime, Clock;
+    import std.file : timeLastModified, setTimes;
+    static import std.process;
+
+    if (!exists(dest_dir))
+        mkdirRecurse(dest_dir);
+
+    foreach (f; dirEntries(src, SpanMode.shallow).filter!(a => a.extension.among(".pu", ".uml"))) {
+        const dst = buildPath(dest_dir, f.name.baseName);
+        if (f.timeLastModified < timeLastModified(dst, SysTime.min)) {
+            writefln("%s not modified thus skipping to update the image", f);
+            continue;
+        }
+
+        writefln("Generating image %s -> %s", f, dst.setExtension("eps"));
+        copy(f.name, dst);
+        setTimes(dst, Clock.currTime, Clock.currTime);
+        try {
+            spawnProcess(["plantuml", "-teps", dst], null, std.process.Config.none, dest_dir).wait;
+        } catch (Exception e) {
+            logger.warning(e.msg);
+        }
+    }
 }
 
 auto run(string[] cmd) {

--- a/plugin/mutate/doc/pandoc.d
+++ b/plugin/mutate/doc/pandoc.d
@@ -26,10 +26,9 @@ void main(string[] args) {
     const string root = getcwd();
 
     const latex_dir = buildPath(root, "latex");
-    if (exists(latex_dir)) {
-        run(["rm", "-r", latex_dir]);
+    if (!exists(latex_dir)) {
+        mkdir(latex_dir);
     }
-    mkdir(latex_dir);
 
     chdir(latex_dir);
     scope (exit)
@@ -100,9 +99,9 @@ void pandoc(Pandoc dat, string[] files, const string output) {
         run(["bibtex", output ~ ".aux"]);
     } catch (Exception e) {
     }
-    // resolve pass 1
+
+    // continue resolving references. At least two times is needed.
     run(["pdflatex", output ~ ".latex"]);
-    // resolve pass 2
     run(["pdflatex", output ~ ".latex"]);
 }
 

--- a/plugin/mutate/doc/pandoc.d
+++ b/plugin/mutate/doc/pandoc.d
@@ -77,8 +77,7 @@ void pandoc(Pandoc dat, string[] files, const string output) {
     // dfmt off
     auto cmd = ["pandoc",
          "--template", dat.latexTemplate,
-         "-f", "markdown_github+citations+yaml_metadata_block+tex_math_dollars+raw_tex",
-         "-S",
+         "-f", "markdown_github+citations+yaml_metadata_block+tex_math_dollars+raw_tex+smart",
          "--standalone",
          "--toc",
          "--bibliography", dat.biblio,

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -189,8 +189,14 @@ struct Analyzer {
         db.put(mdata.data);
     }
 
-    void finalize() @safe {
+    void finalize() @trusted {
+        import dextool.plugin.mutate.backend.test_mutant.timeout : resetTimeoutContext;
+
+        auto t = db.transaction;
+        resetTimeoutContext(db);
         db.removeOrphanedMutants;
+        t.commit;
+
         printPrunedFiles(before_files, files_with_mutations, fio.getOutputDir);
     }
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
@@ -46,10 +46,6 @@ struct Database {
         return Database(SDatabase.make(db), mut_order);
     }
 
-    // Not movable. The database should only be passed around as a reference,
-    // if at all.
-    @disable this(this);
-
     Nullable!Checksum getFileChecksum(const Path p) @trusted {
         import dextool.plugin.mutate.backend.utility : checksum;
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
@@ -12,10 +12,12 @@ module dextool.plugin.mutate.backend.database.type;
 import core.time : Duration;
 import std.datetime : SysTime;
 
+import sumtype;
+
 import dextool.type : AbsolutePath, Path;
 import dextool.plugin.mutate.backend.type;
 
-import sumtype;
+public import dextool.plugin.mutate.backend.database.schema : MutantTimeoutCtx;
 
 @safe:
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/utility.d
@@ -522,7 +522,7 @@ MutationStat reportStatistics(ref Database db, const Mutation.Kind[] kinds, stri
     st.timeout = timeout.count;
     st.untested = untested.count;
     st.total = total.count;
-	st.killedByCompiler = killed_by_compiler.count;
+    st.killedByCompiler = killed_by_compiler.count;
 
     st.totalTime = total.time;
     st.predictedDone = st.total > 0 ? (st.untested * (st.totalTime / st.total)) : 0.dur!"msecs";

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
@@ -1,0 +1,268 @@
+/**
+Copyright: Copyright (c) 2019, Joakim Brännström. All rights reserved.
+License: MPL-2
+Author: Joakim Brännström (joakim.brannstrom@gmx.com)
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+# Analyze
+
+The worklist should not be cleared during an analyze phase.
+Any mutant that has been removed in the source code will be automatically
+removed from the worklist because the tables is setup with ON DELETE CASCADE.
+
+Thus by not removing it old timeout mutants that need more work will be
+"resumed".
+
+# Test
+
+TODO: describe the test phase and FSM
+*/
+module dextool.plugin.mutate.backend.test_mutant.timeout;
+
+import logger = std.experimental.logger;
+import std.exception : collectException;
+import std.typecons : Flag, NullableRef, nullableRef;
+
+import miniorm : spinSql;
+
+import dextool.from;
+import dextool.fsm;
+
+import dextool.plugin.mutate.backend.database : Database, MutantTimeoutCtx, MutationStatusId;
+import dextool.plugin.mutate.backend.type : Mutation;
+
+@safe:
+
+/// Reset the state of the timeout algorithm to its inital state.
+void resetTimeoutContext(ref Database db) @trusted {
+    db.putMutantTimeoutCtx(MutantTimeoutCtx.init);
+}
+
+/// Calculate the timeout to use based on the context.
+std_.datetime.Duration calculateTimeout(const long iter, std_.datetime.Duration base) pure nothrow @nogc {
+    import core.time : dur;
+    import std.math : sqrt;
+
+    static immutable double constant_factor = 1.5;
+    static immutable double scale_factor = 2.0;
+    const double n = iter;
+
+    const double scale = constant_factor + sqrt(n) * scale_factor;
+    return (1L + (cast(long)(base.total!"msecs" * scale))).dur!"msecs";
+}
+
+/** Update the status of a mutant.
+ *
+ * If the mutant is `timeout` then it will be added to the worklist if the
+ * mutation testing is in the initial phase.
+ *
+ * If it has progressed beyond the init phase then it depends on if the local
+ * iteration variable of *this* instance of dextool matches the one in the
+ * database. This ensures that all instances that work on the same database is
+ * in-sync with each other.
+ *
+ * Params:
+ *  db = database to use
+ *  id = ?
+ *  st = ?
+ *  usedIter = the `iter` value that was used to test the mutant
+ */
+void updateMutantStatus(ref Database db, const MutationStatusId id,
+        const Mutation.Status st, const long usedIter) @trusted {
+    import std.typecons : Yes;
+
+    const ctx = db.getMutantTimeoutCtx;
+
+    final switch (ctx.state) with (MutantTimeoutCtx.State) {
+    case init_:
+        if (st == Mutation.Status.timeout)
+            db.putMutantInTimeoutWorklist(id);
+        db.updateMutationStatus(id, st, Yes.updateTs);
+        break;
+    case running:
+        if (usedIter == ctx.iter) {
+            db.updateMutationStatus(id, st, Yes.updateTs);
+        }
+        break;
+    case done:
+        break;
+    }
+}
+
+/** FSM for handling mutants during the test phase.
+ */
+struct TimeoutFsm {
+@safe:
+
+    static struct Init {
+    }
+
+    static struct ResetWorkList {
+    }
+
+    static struct UpdateCtx {
+    }
+
+    static struct Running {
+    }
+
+    static struct Purge {
+        // worklist items and if they have changed or not
+        enum Event {
+            changed,
+            same
+        }
+
+        Event ev;
+    }
+
+    static struct Done {
+    }
+
+    static struct ClearWorkList {
+    }
+
+    static struct Stop {
+    }
+
+    /// Data used by all states.
+    static struct Global {
+        MutantTimeoutCtx ctx;
+        Mutation.Kind[] kinds;
+        NullableRef!Database db;
+    }
+
+    static struct Output {
+        /// The current iteration through the timeout algorithm.
+        long iter;
+        /// When the testing of all timeouts are done, e.g. the state is "done".
+        bool done;
+    }
+
+    /// Output that may be used.
+    Output output;
+
+    private {
+        Fsm!(Init, ResetWorkList, UpdateCtx, Running, Purge, Done, ClearWorkList, Stop) fsm;
+        Global global;
+    }
+
+    this(const Mutation.Kind[] kinds) nothrow {
+        global.kinds = kinds.dup;
+    }
+
+    void execute(ref Database db) @trusted {
+        global.db = nullableRef(&db);
+
+        auto t = db.transaction;
+        global.ctx = db.getMutantTimeoutCtx;
+
+        // force the local state to match the starting point in the ctx
+        // (database).
+        final switch (global.ctx.state) with (MutantTimeoutCtx) {
+        case State.init_:
+            fsm.state = fsm(Init.init);
+            break;
+        case State.running:
+            fsm.state = fsm(Running.init);
+            break;
+        case State.done:
+            fsm.state = fsm(Done.init);
+            break;
+        }
+
+        // act on the inital state
+        try {
+            fsm.act!this;
+        } catch (Exception e) {
+            logger.warning(e.msg).collectException;
+        }
+
+        while (!fsm.isState!Stop) {
+            try {
+                step(db);
+            } catch (Exception e) {
+                logger.warning(e.msg).collectException;
+            }
+        }
+
+        db.putMutantTimeoutCtx(global.ctx);
+        t.commit;
+
+        output.iter = global.ctx.iter;
+    }
+
+    private void step(ref Database db) @safe {
+        bool noUnknown() {
+            return db.unknownSrcMutants(global.kinds, null).count == 0;
+        }
+
+        fsm.next!((Init a) {
+            if (noUnknown)
+                return fsm(ResetWorkList.init);
+            return fsm(Stop.init);
+        }, (ResetWorkList a) => fsm(UpdateCtx.init), (UpdateCtx a) => fsm(Running.init), (Running a) {
+            if (noUnknown)
+                return fsm(Purge.init);
+            return fsm(Stop.init);
+        }, (Purge a) {
+            final switch (a.ev) with (Purge.Event) {
+            case changed:
+                return fsm(ResetWorkList.init);
+            case same:
+                return fsm(ClearWorkList.init);
+            }
+        }, (ClearWorkList a) => fsm(Done.init), (Done a) {
+            // happens if an operation is performed that changes the status of
+            // already tested mutants to unknown.
+            if (noUnknown)
+                return fsm(Stop.init);
+            return fsm(Init.init);
+        }, (Stop a) => fsm(a),);
+
+        fsm.act!this;
+    }
+
+    void opCall(Init) {
+        global.ctx = MutantTimeoutCtx.init;
+        output.done = false;
+    }
+
+    void opCall(ResetWorkList) {
+        global.db.resetMutantTimeoutWorklist;
+    }
+
+    void opCall(UpdateCtx) {
+        global.ctx.iter += 1;
+        global.ctx.worklistCount = global.db.countMutantTimeoutWorklist;
+    }
+
+    void opCall(Running) {
+        global.ctx.state = MutantTimeoutCtx.State.running;
+        output.done = false;
+    }
+
+    void opCall(ref Purge data) {
+        global.db.reduceMutantTimeoutWorklist;
+
+        if (global.db.countMutantTimeoutWorklist == global.ctx.worklistCount)
+            data.ev = Purge.Event.same;
+        else
+            data.ev = Purge.Event.changed;
+    }
+
+    void opCall(Done) {
+        global.ctx.state = MutantTimeoutCtx.State.done;
+        output.done = true;
+    }
+
+    void opCall(ClearWorkList) {
+        global.db.clearMutantTimeoutWorklist;
+    }
+
+    void opCall(Stop) {
+    }
+}

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
@@ -50,7 +50,7 @@ struct SourceLoc {
 struct Mutation {
     /// States what kind of mutations that can be performed on this mutation point.
     // ONLY ADD NEW ITEMS TO THE END
-    enum Kind {
+    enum Kind : uint {
         /// the kind is not initialized thus can only ignore the point
         none,
         /// Relational operator replacement

--- a/plugin/mutate/test/test_report.d
+++ b/plugin/mutate/test/test_report.d
@@ -414,7 +414,7 @@ class ShallTagLinesWithNoMutAttr : LinesWithNoMut {
         fid.isNull.shouldBeFalse;
         fid2.isNull.shouldBeFalse;
         foreach (line; [11,12,14,24,32]) {
-            auto m = db.getLineMetadata(fid, SourceLoc(line,0));
+            auto m = db.getLineMetadata(fid.get, SourceLoc(line,0));
             m.attr.match!((NoMetadata a) {shouldBeFalse(true);},
                      (NoMut) {
                          m.id.shouldEqual(fid);
@@ -422,7 +422,7 @@ class ShallTagLinesWithNoMutAttr : LinesWithNoMut {
             });
         }
         foreach (line; [8,9])
-            db.getLineMetadata(fid, SourceLoc(line,0)).isNoMut.shouldBeFalse;
+            db.getLineMetadata(fid.get, SourceLoc(line,0)).isNoMut.shouldBeFalse;
     }
 }
 


### PR DESCRIPTION
- multiple instances of dextool running in parallel
- only re-test those timeouts that has been changed