### PR TITLE
mutate: added so restrictDir is used in analyze-phase.

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -112,6 +112,8 @@ struct Analyzer {
 
         if (analyzed_files.contains(checked_in_file))
             return;
+        if (!val_loc.shouldAnalyze(checked_in_file))
+            return;
 
         analyzed_files.add(checked_in_file);
 


### PR DESCRIPTION
In [#938](https://github.com/joakim-brannstrom/dextool/issues/938), I noticed that the analyze-phase was not restricted to the correct path, as given in the configuration file. The addition in this PR is for handling that, and not the rest of the issue.

Since the FrontendValidateLoc was setup earlier in frontend.d, where the restrictDir was used, the only addition needed was to call the _shouldAnalyze_-function.