### PR TITLE
mutate: allow the user to exclude files from being analyzed for mutants

### DIFF
--- a/libs/dextool/source/dextool/utility.d
+++ b/libs/dextool/source/dextool/utility.d
@@ -109,3 +109,11 @@ string asAbsNormPath(string path) @trusted {
 
     return to!string(path.asAbsolutePath.asNormalizedPath);
 }
+
+/// Returns. true if `path` is inside `root`.
+bool isPathInsideRoot(AbsolutePath root, AbsolutePath path) {
+    import std.string : startsWith;
+    import dextool.utility;
+
+    return (cast(string) path).startsWith(cast(string) root);
+}

--- a/plugin/mutate/doc/design/analyzer/analyzer.md
+++ b/plugin/mutate/doc/design/analyzer/analyzer.md
@@ -105,3 +105,24 @@ partof: REQ-uc_understand_analyze
 ###
 
 The plugin shall print a message containing the root directory and restrictions when beginning analyze for mutants.
+
+# REQ-mutant_analyze_speedup
+partof: REQ-purpose
+###
+
+The user may have source code in its repository that is part of the build
+system but that is uninteresting to perform mutation testing on. This code can
+be of a significant size that negatively affects the performance of the plugin
+when it is analysing the source code for mutants. This has an exceptional
+negative impact when the user wants fast feedback from the mutation testing
+when it is integrated in a pull request workflow.
+
+It is thus important for the analysis phase to be as fast as possible but to
+also provide the user with the needed tools to control what is analyzed.
+
+# SPC-exclude_files_from_analysis
+partof: REQ-mutant_analyze_speedup
+###
+
+The plugin shall exclude files from being analyzed based on a list of
+directories/files to ignore when analysing for mutants.

--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -70,6 +70,12 @@ struct ConfigCompileDb {
     CompileCommandFilter flagFilter;
 }
 
+/// Configuration of how the mutation analyzer should act.
+struct ConfigAnalyze {
+    /// Exclude any files that are in these directory trees from the analysis.
+    AbsolutePath[] exclude;
+}
+
 /// Settings for the compiler
 struct ConfigCompiler {
     import dextool.compilation_db : SystemCompiler = Compiler;

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
@@ -178,6 +178,7 @@ final class FrontendIO : FilesysIO {
 
 private:
     // assuming that root is already a realpath
+    // TODO: replace this function with dextool.utility.isPathInsideRoot
     static void verifyPathInsideRoot(AbsolutePath root, AbsolutePath p, bool dry_run) {
         import std.format : format;
         import std.string : startsWith;
@@ -271,7 +272,8 @@ ExitStatusType modeAnalyze(ref ArgParser conf, ref DataAccess dacc) {
 
     printFileAnalyzeHelp(conf);
 
-    return runAnalyzer(dacc.db, conf.compiler, dacc.frange, dacc.validateLoc, dacc.io);
+    return runAnalyzer(dacc.db, conf.analyze, conf.compiler, dacc.frange,
+            dacc.validateLoc, dacc.io);
 }
 
 ExitStatusType modeGenerateMutant(ref ArgParser conf, ref DataAccess dacc) {

--- a/plugin/mutate/test/test_analyzer.d
+++ b/plugin/mutate/test/test_analyzer.d
@@ -5,6 +5,13 @@ Author: Joakim Brännström (joakim.brannstrom@gmx.com)
 */
 module dextool_test.test_analyzer;
 
+import std.path : relativePath;
+
+import dextool.plugin.mutate.backend.database.standalone;
+import dextool.plugin.mutate.backend.database.type;
+import dextool.plugin.mutate.backend.type;
+static import dextool.type;
+
 import dextool_test.utility;
 
 // dfmt off
@@ -15,4 +22,27 @@ unittest {
     makeDextoolAnalyze(testEnv)
         .addInputArg(testData ~ "all_kinds_of_abs_mutation_points.cpp")
         .run;
+}
+
+@(testId ~ "shall exclude files from the analysis they are part of an excluded directory tree when analysing")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+
+    const programFile1 = testData ~ "analyze/file1.cpp";
+    const programFile2 = testData ~ "analyze/exclude/file2.cpp";
+
+    makeDextoolAnalyze(testEnv)
+        .addInputArg(programFile1)
+        .addInputArg(programFile2)
+        .addPostArg(["--file-exclude", (testData ~ "analyze/exclude").toString])
+        .run;
+
+    // assert
+    auto db = Database.make((testEnv.outdir ~ defaultDb).toString);
+
+    const file1 = dextool.type.Path(relativePath(programFile1.toString, workDir.toString));
+    const file2 = dextool.type.Path(relativePath(programFile2.toString, workDir.toString));
+
+    db.getFileId(file1).isNull.shouldBeFalse;
+    db.getFileId(file2).isNull.shouldBeTrue;
 }

--- a/plugin/mutate/testdata/analyze/exclude/file2.cpp
+++ b/plugin/mutate/testdata/analyze/exclude/file2.cpp
@@ -1,0 +1,10 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2019
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+
+int wun(int x) {
+    if (x > 3) {
+        return 0;
+    }
+    return 1;
+}

--- a/plugin/mutate/testdata/analyze/file1.cpp
+++ b/plugin/mutate/testdata/analyze/file1.cpp
@@ -1,0 +1,10 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2019
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+
+int fun(int x) {
+    if (x > 3) {
+        return 0;
+    }
+    return 1;
+}


### PR DESCRIPTION
This speeds up the analysis because the user can exclude those files
that aren't of interest to mutant such as external libraries.