### PR TITLE
mutate: simplify and improve generate implementation

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -150,3 +150,8 @@ struct ConfigWorkArea {
     AbsolutePath outputDirectory;
     AbsolutePath[] restrictDir;
 }
+
+/// Configuration of the generate mode.
+struct ConfigGenerate {
+    long mutationId;
+}

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -50,6 +50,7 @@ struct ArgParser {
     ConfigMutationTest mutationTest;
     ConfigReport report;
     ConfigWorkArea workArea;
+    ConfigGenerate generate;
 
     struct Data {
         string[] inFiles;
@@ -60,8 +61,6 @@ struct ArgParser {
         ExitStatusType exitStatus = ExitStatusType.Ok;
 
         MutationKind[] mutation;
-
-        Nullable!long mutationId;
 
         ToolMode toolMode;
     }
@@ -222,26 +221,15 @@ struct ArgParser {
 
         void generateMutantG(string[] args) {
             data.toolMode = ToolMode.generate_mutant;
-            string cli_mutation_id;
             // dfmt off
             help_info = getopt(args, std.getopt.config.keepEndOfOptions,
                    "c|config", conf_help, &conf_file,
                    "db", db_help, &db,
                    "out", out_help, &workArea.rawRoot,
                    "restrict", restrict_help, &workArea.rawRestrict,
-                   "id", "mutate the source code as mutant ID", &cli_mutation_id,
+                   std.getopt.config.required, "id", "mutate the source code as mutant ID", &generate.mutationId,
                    );
             // dfmt on
-
-            try {
-                import std.conv : to;
-
-                if (cli_mutation_id.length != 0)
-                    data.mutationId = cli_mutation_id.to!long;
-            } catch (ConvException e) {
-                logger.infof("Invalid mutation point '%s'. It must be in the range [0, %s]",
-                        cli_mutation_id, long.max);
-            }
         }
 
         void testMutantsG(string[] args) {

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/frontend.d
@@ -278,9 +278,10 @@ ExitStatusType modeAnalyze(ref ArgParser conf, ref DataAccess dacc) {
 
 ExitStatusType modeGenerateMutant(ref ArgParser conf, ref DataAccess dacc) {
     import dextool.plugin.mutate.backend : runGenerateMutant;
+    import dextool.plugin.mutate.backend.database.type : MutationId;
 
-    return runGenerateMutant(dacc.db, conf.data.mutation, conf.data.mutationId,
-            dacc.io, dacc.validateLoc);
+    return runGenerateMutant(dacc.db, conf.data.mutation,
+            MutationId(conf.generate.mutationId), dacc.io, dacc.validateLoc);
 }
 
 ExitStatusType modeTestMutants(ref ArgParser conf, ref DataAccess dacc) {


### PR DESCRIPTION
Remove unused functionality.
Tag required CLI parameter.
Wrap config specific data in its own type.