### PR TITLE
mutate: only create a fused compile commands database when needed by a

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -34,7 +34,7 @@ version (unittest) {
 /** Analyze the files in `frange` for mutations.
  */
 ExitStatusType runAnalyzer(ref Database db, ConfigAnalyze conf_analyze,
-        ConfigCompiler conf_compiler, ref UserFileRange frange, ValidateLoc val_loc, FilesysIO fio) @trusted {
+        ConfigCompiler conf_compiler, UserFileRange frange, ValidateLoc val_loc, FilesysIO fio) @trusted {
     import std.algorithm : filter, map;
 
     auto analyzer = Analyzer(db, val_loc, fio, conf_compiler);


### PR DESCRIPTION
mode. There are modes that do not require a database but because it
where always created by the frontend errored out.