### PR TITLE
mutate: allow the user to specify the test case analyzer as a shell

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -99,7 +99,7 @@ struct ConfigCompiler {
 struct ConfigMutationTest {
     ShellCommand mutationTester;
     ShellCommand mutationCompile;
-    AbsolutePath mutationTestCaseAnalyze;
+    ShellCommand mutationTestCaseAnalyze;
     TestCaseAnalyzeBuiltin[] mutationTestCaseBuiltin;
     Nullable!Duration mutationTesterRuntime;
     MutationOrder mutationOrder;

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -269,7 +269,8 @@ struct ArgParser {
             if (mutationCompile.length != 0)
                 mutationTest.mutationCompile = ShellCommand.fromString(mutationCompile);
             if (mutationTestCaseAnalyze.length != 0)
-                mutationTest.mutationTestCaseAnalyze = Path(mutationTestCaseAnalyze).AbsolutePath;
+                mutationTest.mutationTestCaseAnalyze = ShellCommand.fromString(
+                        mutationTestCaseAnalyze);
             if (mutationTesterRuntime != 0)
                 mutationTest.mutationTesterRuntime = mutationTesterRuntime.dur!"msecs";
             if (!maxRuntime.empty)
@@ -566,7 +567,7 @@ void loadConfig(ref ArgParser rval) @trusted {
         c.mutationTest.mutationCompile = ShellCommand.fromString(v.str);
     };
     callbacks["mutant_test.analyze_cmd"] = (ref ArgParser c, ref TOMLValue v) {
-        c.mutationTest.mutationTestCaseAnalyze = Path(v.str).AbsolutePath;
+        c.mutationTest.mutationTestCaseAnalyze = ShellCommand.fromString(v.str);
     };
     callbacks["mutant_test.analyze_using_builtin"] = (ref ArgParser c, ref TOMLValue v) {
         c.mutationTest.mutationTestCaseBuiltin = v.array.map!(


### PR DESCRIPTION
command.