### PR TITLE
mutate: improve how a user can specify test, build and analyze commands

### DIFF
--- a/plugin/mutate/README.md
+++ b/plugin/mutate/README.md
@@ -64,8 +64,8 @@ extra_flags = [ "-D_POSIX_PATH_MAX=1024" ]
 [compile_commands]
 search_paths = ["./build/compile_commands.json"]
 [mutant_test]
-test_cmd = "test.sh"
-build_cmd = "build.sh"
+test_cmd = "./test.sh"
+build_cmd = "./build.sh"
 analyze_using_builtin = ["gtest"]
 ```
 

--- a/plugin/mutate/examples/algo_test/.dextool_mutate.toml
+++ b/plugin/mutate/examples/algo_test/.dextool_mutate.toml
@@ -29,11 +29,11 @@ search_paths = ["./build/compile_commands.json"]
 
 [mutant_test]
 # (required) program used to run the test suite
-test_cmd = "test.sh"
+test_cmd = "./test.sh"
 # timeout to use for the test suite (msecs)
 # test_cmd_timeout = 1000
 # (required) program used to build the application
-build_cmd = "build.sh"
+build_cmd = "./build.sh"
 # program used to analyze the output from the test suite for test cases that killed the mutant
 # analyze_cmd = "analyze.sh"
 # builtin analyzer of output from testing frameworks to find failing test cases

--- a/plugin/mutate/examples/game_tutorial/.dextool_mutate.toml
+++ b/plugin/mutate/examples/game_tutorial/.dextool_mutate.toml
@@ -34,10 +34,14 @@ search_paths = ["./build/compile_commands.json"]
 
 [mutant_test]
 # (required) program used to run the test suite
+# the arguments for test_cmd can be an array of multiple test commands
+# 1. ["test1.sh", "test2.sh"]
+# 2. [["test1.sh", "-x"], "test2.sh"]
 test_cmd = "./build/rl_test"
 # timeout to use for the test suite (msecs)
 # test_cmd_timeout = 1000
 # (required) program used to build the application
+# the arguments for build_cmd can be an array: ["build.sh", "-x"]
 build_cmd = "./build.sh"
 # program used to analyze the output from the test suite for test cases that killed the mutant
 # analyze_cmd = "analyze.sh"

--- a/plugin/mutate/examples/gtest/.dextool_mutate.toml
+++ b/plugin/mutate/examples/gtest/.dextool_mutate.toml
@@ -5,6 +5,6 @@ extra_flags = [ "-D_POSIX_PATH_MAX=1024" ]
 [compile_commands]
 search_paths = ["./build/compile_commands.json"]
 [mutant_test]
-test_cmd = "test.sh"
-build_cmd = "build.sh"
+test_cmd = "./test.sh"
+build_cmd = "./build.sh"
 analyze_using_builtin = ["gtest", "ctest"]

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
@@ -53,11 +53,19 @@ struct TestRunner {
         pool.stop;
     }
 
+    bool empty() @safe pure nothrow const @nogc {
+        return commands.length == 0;
+    }
+
     void timeout(Duration timeout) pure nothrow @nogc {
         this.timeout_ = timeout;
     }
 
     void put(ShellCommand sh) pure nothrow {
+        commands ~= sh;
+    }
+
+    void put(ShellCommand[] sh) pure nothrow {
         commands ~= sh;
     }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -97,7 +97,7 @@ struct ConfigCompiler {
 
 /// Settings for mutation testing
 struct ConfigMutationTest {
-    ShellCommand mutationTester;
+    ShellCommand[] mutationTester;
     ShellCommand mutationCompile;
     ShellCommand mutationTestCaseAnalyze;
     TestCaseAnalyzeBuiltin[] mutationTestCaseBuiltin;

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -137,10 +137,14 @@ struct ArgParser {
 
         app.put("[mutant_test]");
         app.put("# (required) program used to run the test suite");
+        app.put(`# the arguments for test_cmd can be an array of multiple test commands`);
+        app.put(`# 1. ["test1.sh", "test2.sh"]`);
+        app.put(`# 2. [["test1.sh", "-x"], "test2.sh"]`);
         app.put(`test_cmd = "test.sh"`);
         app.put("# timeout to use for the test suite (msecs)");
         app.put("# test_cmd_timeout = 1000");
         app.put("# (required) program used to build the application");
+        app.put(`# the arguments for build_cmd can be an array: ["build.sh", "-x"]`);
         app.put(`build_cmd = "build.sh"`);
         app.put(
                 "# program used to analyze the output from the test suite for test cases that killed the mutant");
@@ -232,7 +236,7 @@ struct ArgParser {
         }
 
         void testMutantsG(string[] args) {
-            string mutationTester;
+            string[] mutationTester;
             string mutationCompile;
             string mutationTestCaseAnalyze;
             long mutationTesterRuntime;
@@ -265,7 +269,8 @@ struct ArgParser {
             if (maxAlive > 0)
                 mutationTest.maxAlive = maxAlive;
             if (mutationTester.length != 0)
-                mutationTest.mutationTester = ShellCommand.fromString(mutationTester);
+                mutationTest.mutationTester = mutationTester.map!(a => ShellCommand.fromString(a))
+                    .array;
             if (mutationCompile.length != 0)
                 mutationTest.mutationCompile = ShellCommand.fromString(mutationCompile);
             if (mutationTestCaseAnalyze.length != 0)
@@ -493,9 +498,7 @@ void printFileAnalyzeHelp(ref ArgParser ap) @safe {
  * ---
  */
 void loadConfig(ref ArgParser rval) @trusted {
-    import std.conv : to;
     import std.file : exists, readText;
-    import std.path : dirName, buildPath;
     import toml;
 
     if (!exists(rval.miniConf.confFile))
@@ -517,8 +520,39 @@ void loadConfig(ref ArgParser rval) @trusted {
         return;
     }
 
+    rval = loadConfig(rval, doc);
+}
+
+ArgParser loadConfig(ArgParser rval, ref TOMLDocument doc) @trusted {
+    import std.conv : to;
+    import std.path : dirName, buildPath;
+    import toml;
+
     alias Fn = void delegate(ref ArgParser c, ref TOMLValue v);
     Fn[string] callbacks;
+
+    static ShellCommand toShellCommand(ref TOMLValue v, string errorMsg) {
+        if (v.type == TOML_TYPE.STRING) {
+            return ShellCommand.fromString(v.str);
+        } else if (v.type == TOML_TYPE.ARRAY) {
+            return ShellCommand(v.array.map!(a => a.str).array);
+        }
+        logger.warning(errorMsg);
+        return ShellCommand.init;
+    }
+
+    static ShellCommand[] toShellCommands(ref TOMLValue v, string errorMsg) {
+        import std.format : format;
+
+        if (v.type == TOML_TYPE.STRING) {
+            return [ShellCommand.fromString(v.str)];
+        } else if (v.type == TOML_TYPE.ARRAY) {
+            return v.array.map!(a => toShellCommand(a,
+                    format!"%s: failed to parse as an array"(errorMsg))).array;
+        }
+        logger.warning(errorMsg);
+        return ShellCommand[].init;
+    }
 
     callbacks["analyze.exclude"] = (ref ArgParser c, ref TOMLValue v) {
         c.analyze.rawExclude = v.array.map!(a => a.str).array;
@@ -558,16 +592,19 @@ void loadConfig(ref ArgParser rval) @trusted {
     };
 
     callbacks["mutant_test.test_cmd"] = (ref ArgParser c, ref TOMLValue v) {
-        c.mutationTest.mutationTester = ShellCommand.fromString(v.str);
+        c.mutationTest.mutationTester = toShellCommands(v,
+                "config: failed to parse mutant_test.test_cmd");
     };
     callbacks["mutant_test.test_cmd_timeout"] = (ref ArgParser c, ref TOMLValue v) {
         c.mutationTest.mutationTesterRuntime = v.integer.dur!"msecs";
     };
     callbacks["mutant_test.build_cmd"] = (ref ArgParser c, ref TOMLValue v) {
-        c.mutationTest.mutationCompile = ShellCommand.fromString(v.str);
+        c.mutationTest.mutationCompile = toShellCommand(v,
+                "config: failed to parse mutant_test.build_cmd");
     };
     callbacks["mutant_test.analyze_cmd"] = (ref ArgParser c, ref TOMLValue v) {
-        c.mutationTest.mutationTestCaseAnalyze = ShellCommand.fromString(v.str);
+        c.mutationTest.mutationTestCaseAnalyze = toShellCommand(v,
+                "config: failed to parse mutant_test.analyze_cmd");
     };
     callbacks["mutant_test.analyze_using_builtin"] = (ref ArgParser c, ref TOMLValue v) {
         c.mutationTest.mutationTestCaseBuiltin = v.array.map!(
@@ -634,6 +671,8 @@ void loadConfig(ref ArgParser rval) @trusted {
     iterSection(rval, "report");
 
     parseTestGroups(rval, doc);
+
+    return rval;
 }
 
 void parseTestGroups(ref ArgParser c, ref TOMLDocument doc) @trusted {
@@ -653,6 +692,55 @@ void parseTestGroups(ref ArgParser c, ref TOMLDocument doc) @trusted {
             string re = v.str;
             c.report.testGroups ~= TestGroup(k, desc, re);
         }
+    }
+}
+
+@("shall populate the test, build and analyze command of an ArgParser from a TOML document")
+@system unittest {
+    import std.format : format;
+    import toml : parseTOML;
+
+    immutable txt = `
+[mutant_test]
+test_cmd = %s
+build_cmd = %s
+analyze_cmd = %s
+`;
+
+    {
+        auto doc = parseTOML(format!txt(`"test.sh"`, `"build.sh"`, `"analyze.sh"`));
+        auto ap = loadConfig(ArgParser.init, doc);
+        ap.mutationTest.mutationTester.shouldEqual([ShellCommand(["test.sh"])]);
+        ap.mutationTest.mutationCompile.shouldEqual(ShellCommand(["build.sh"]));
+        ap.mutationTest.mutationTestCaseAnalyze.shouldEqual(ShellCommand([
+                    "analyze.sh"
+                ]));
+    }
+
+    {
+        auto doc = parseTOML(format!txt(`[["test1.sh"], ["test2.sh"]]`,
+                `["build.sh", "-y"]`, `["analyze.sh", "-z"]`));
+        auto ap = loadConfig(ArgParser.init, doc);
+        ap.mutationTest.mutationTester.shouldEqual([
+                ShellCommand(["test1.sh"]), ShellCommand(["test2.sh"])
+                ]);
+        ap.mutationTest.mutationCompile.shouldEqual(ShellCommand([
+                    "build.sh", "-y"
+                ]));
+        ap.mutationTest.mutationTestCaseAnalyze.shouldEqual(ShellCommand([
+                    "analyze.sh", "-z"
+                ]));
+    }
+
+    {
+        auto doc = parseTOML(format!txt(`[["test1.sh", "-x"], ["test2.sh", "-y"]]`,
+                `"build.sh"`, `"analyze.sh"`));
+        auto ap = loadConfig(ArgParser.init, doc);
+        ap.mutationTest.mutationTester.shouldEqual([
+                ShellCommand(["test1.sh", "-x"]), ShellCommand([
+                        "test2.sh", "-y"
+                    ])
+                ]);
     }
 }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/type.d
@@ -169,8 +169,7 @@ struct ShellCommand {
         import std.array : split;
 
         string[] args = cmd.split!isWhite;
-        string program = args[0].Path.AbsolutePath;
-        return ShellCommand(program ~ args[1 .. $]);
+        return ShellCommand(args);
     }
 
     bool empty() @safe pure nothrow const @nogc {


### PR DESCRIPTION
Allow the user to specify multiple test commands that are executed in
parallel.

Allow a user to specify the commands as an array of arguments. This
make it possible for the user to specify arguments that e.g. contains a
whitespace.