### PR TITLE
mutate: allow the user to configure how many tests are executed in

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -697,7 +697,7 @@ struct TestDriver {
         local.get!NextPullRequestMutant.maxAlive = global.data.conf.maxAlive;
         local.get!ResetOldMutant.maxReset = global.data.conf.oldMutantsNr;
 
-        this.runner = TestRunner.make;
+        this.runner = TestRunner.make(global.data.conf.testPoolSize);
         // using an unreasonable timeout to make it possible to analyze for
         // test cases and measure the test suite.
         this.runner.timeout = 999.dur!"hours";

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
@@ -43,8 +43,13 @@ struct TestRunner {
     /// Environment to set when executing either binaries or the command.
     string[string] env;
 
-    static auto make() {
-        auto pool = new TaskPool;
+    static auto make(int poolSize) {
+        auto pool = () {
+            if (poolSize == 0) {
+                return new TaskPool;
+            }
+            return new TaskPool(poolSize);
+        }();
         pool.isDaemon = true;
         return TestRunner(pool);
     }
@@ -232,7 +237,7 @@ unittest {
             remove(script);
     }();
 
-    auto runner = TestRunner.make;
+    auto runner = TestRunner.make(0);
     runner.put([script, "foo", "0"].ShellCommand);
     runner.put([script, "foo", "0"].ShellCommand);
     auto res = runner.run(5.dur!"seconds");
@@ -251,7 +256,7 @@ unittest {
             remove(script);
     }();
 
-    auto runner = TestRunner.make;
+    auto runner = TestRunner.make(0);
     runner.put([script, "foo", "0"].ShellCommand);
     runner.put([script, "foo", "1"].ShellCommand);
     auto res = runner.run(5.dur!"seconds");
@@ -270,7 +275,7 @@ unittest {
             remove(script);
     }();
 
-    auto runner = TestRunner.make;
+    auto runner = TestRunner.make(0);
     runner.put([script, "foo", "0"].ShellCommand);
     runner.put([script, "foo", "0", "timeout"].ShellCommand);
     auto res = runner.run(1.dur!"seconds");

--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -147,6 +147,9 @@ struct ConfigMutationTest {
 
     /// Stop after this many alive mutants are found. Only effective if constraint.empty is false.
     Nullable!int maxAlive;
+
+    /// The size of the thread pool which affects how many tests are executed in parallel.
+    int testPoolSize;
 }
 
 /// Settings for the administration mode


### PR DESCRIPTION
parallel.