### PR TITLE
mutate: fix performance regression when reporting statistics

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/package.d
@@ -164,8 +164,6 @@ struct Database {
                 d.slocEnd = SourceLoc(r.peek!uint(8), r.peek!uint(9));
                 d.lang = r.peek!long(13).to!Language;
 
-                d.testCases = db.getTestCases(d.id);
-
                 if (r.peek!long(14) != 0)
                     d.attrs = MutantMetaData(d.id, MutantAttr(NoMut.init));
                 dg(d);
@@ -253,7 +251,6 @@ struct IterateMutantRow {
     Checksum fileChecksum;
     SourceLoc sloc;
     SourceLoc slocEnd;
-    TestCase[] testCases;
     Language lang;
     MutantMetaData attrs;
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/compiler.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/compiler.d
@@ -55,7 +55,7 @@ import dextool.plugin.mutate.type : MutationKind, ReportLevel;
     override void locationStartEvent(ref Database db) {
     }
 
-    override void locationEvent(const ref IterateMutantRow r) @trusted {
+    override void locationEvent(ref Database db, const ref IterateMutantRow r) @trusted {
         import dextool.plugin.mutate.backend.generate_mutant : makeMutation;
 
         void report() {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/csv.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/csv.d
@@ -58,7 +58,7 @@ final class ReportCSV : ReportEvent {
     override void locationStartEvent(ref Database db) {
     }
 
-    override void locationEvent(const ref IterateMutantRow r) @trusted {
+    override void locationEvent(ref Database db, const ref IterateMutantRow r) @trusted {
         import std.conv : to;
 
         void report() {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/markdown.d
@@ -181,7 +181,7 @@ struct Markdown(Writer, TraceWriter) {
         }
     }
 
-    override void locationEvent(const ref IterateMutantRow r) @trusted {
+    override void locationEvent(ref Database db, const ref IterateMutantRow r) @trusted {
         void report() {
             MakeMutationTextResult mut_txt;
             try {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/type.d
@@ -31,7 +31,7 @@ alias SimpleWriter = void delegate(const(char)[]) @safe;
     /// The printer is informed of what kind of mutants there are.
     void mutationKindEvent(const MutationKind[]);
     void locationStartEvent(ref Database db);
-    void locationEvent(const ref IterateMutantRow);
+    void locationEvent(ref Database db, const ref IterateMutantRow);
     void locationEndEvent();
     void locationStatEvent();
     void statEvent(ref Database db);


### PR DESCRIPTION
The improvement for a small example is from 12s to 0,3s.
The call to db.getTestCases(mutationId) was the culprit. It should only be done when it is needed.