### PR TITLE
miniorm: add a limit to the number of cached statements to avoid an

### DIFF
--- a/vendor/miniorm/source/miniorm/api.d
+++ b/vendor/miniorm/source/miniorm/api.d
@@ -57,6 +57,12 @@ struct Miniorm {
     }
 
     RefCntStatement prepare(string sql) {
+        // TODO: workaround to ensure it doesn't grow uncontrollably. Implement
+        // some kind of improved logic in the future which has e.g. a TTL.
+        if (cachedStmt.length > 128) {
+            cachedStmt.clear;
+        }
+
         if (auto v = sql in cachedStmt) {
             return RefCntStatement(*v);
         }
@@ -76,8 +82,9 @@ struct Miniorm {
     }
 
     private void cleanupCache() {
-        foreach (ref s; cachedStmt.byValue)
+        foreach (ref s; cachedStmt.byValue) {
             s.finalize;
+        }
         cachedStmt = null;
     }
 


### PR DESCRIPTION
infinite growth.