### PR TITLE
mutate: fix livelock when a process is a zombie but keep stdout/stderr

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
@@ -229,7 +229,7 @@ bool externalProgram(ShellCommand cmd, DrainElement[] output,
         cleanup.add(tmpdir.Path.AbsolutePath);
         cmd = writeOutput(cmd);
         auto p = pipeProcess(cmd.value).sandbox.scopeKill;
-        foreach (l; p.process.drainByLineCopy(1.dur!"hours").map!(a => a.strip)
+        foreach (l; p.process.drainByLineCopy(200.dur!"msecs").map!(a => a.strip)
                 .filter!(a => !a.empty)) {
             if (l.startsWith(passed))
                 report.reportFound(TestCase(l[passed.length .. $].strip.idup));
@@ -314,7 +314,7 @@ CompileResult compile(ShellCommand cmd) nothrow {
     import process;
 
     try {
-        auto p = pipeProcess(cmd.value).sandbox.drainToNull(999.dur!"hours").scopeKill;
+        auto p = pipeProcess(cmd.value).sandbox.drainToNull(200.dur!"msecs").scopeKill;
         if (p.wait != 0) {
             return CompileResult(Mutation.Status.killedByCompiler);
         }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/test_cmd_runner.d
@@ -15,7 +15,7 @@ module dextool.plugin.mutate.backend.test_mutant.test_cmd_runner;
 import logger = std.experimental.logger;
 import std.algorithm : filter;
 import std.array : appender, Appender, empty;
-import std.datetime : Duration;
+import std.datetime : Duration, dur;
 import std.exception : collectException;
 import std.parallelism : TaskPool, Task, task;
 
@@ -194,7 +194,7 @@ RunResult spawnRunTest(string[] cmd, Duration timeout, string[string] env) @trus
     try {
         auto p = pipeProcess(cmd, std.process.Redirect.all, env).sandbox.timeout(timeout).scopeKill;
         auto output = appender!(DrainElement[])();
-        p.process.drain(timeout).copy(output);
+        p.process.drain(200.dur!"msecs").copy(output);
 
         if (p.timeoutTriggered) {
             rval.status = RunResult.Status.timeout;


### PR DESCRIPTION
open thus the draining is waiting for data but it will never arrive.