### PR TITLE
mutate: always kill the process because it may be a sandbox which is

### DIFF
--- a/plugin/mutate/source/process/package.d
+++ b/plugin/mutate/source/process/package.d
@@ -451,8 +451,11 @@ struct Timeout(ProcessT) {
             }
         }
 
+        // may be children alive thus must ensure that the whole process tree
+        // is killed if this is a sandbox with a timeout.
+        bg.kill;
+
         if (!forceStop && Clock.currTime >= stopAt) {
-            bg.kill;
             bg.setReply(Reply.killedByTimeout);
         } else {
             bg.setReply(Reply.normalDeath);


### PR DESCRIPTION
actually a process tree.