### PR TITLE
mutate: change default operators

### DIFF
--- a/plugin/mutate/doc/design/mutations.md
+++ b/plugin/mutate/doc/design/mutations.md
@@ -250,7 +250,15 @@ and concluding that if LCR is updated then LCRb should also be updated.
 partof: REQ-mutations
 ###
 
-TODO: add requirement.
+The plugins shall mutate `!` in unary expressions by removing it.
+
+## Note
+
+The operator do not fully implement the academical definition of UOI. After
+practical use it was found that UOI produces a large number of unproductive
+mutants. This lead to the redesign of how it mutates. Instead of mutating
+everything it can it now only generate mutants that is highly likely to be
+productive. Less "false positives".
 
 ## Unary Operator Insertion (UOI)
 Insert a single unary operator in expressions where it is possible.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/package.d
@@ -31,7 +31,7 @@ Mutation.Kind[] toInternal(const MutationKind[] k) @safe pure nothrow {
 
     auto kinds(const MutationKind k) {
         final switch (k) with (MutationKind) {
-        case any:
+        case all:
             return [EnumMembers!(Mutation.Kind)];
         case ror:
             return rorMutationsAll.dup;
@@ -56,7 +56,7 @@ Mutation.Kind[] toInternal(const MutationKind[] k) @safe pure nothrow {
         }
     }
 
-    return (k is null ? [MutationKind.any] : k).map!(a => kinds(a)).joiner.array;
+    return (k is null ? [MutationKind.all] : k).map!(a => kinds(a)).joiner.array;
 }
 
 /// Convert the internal mutation kind to those that are presented to the user via the CLI.

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -436,7 +436,10 @@ struct ArgParser {
                 workArea.outputDirectory)).array;
 
         if (data.mutation.empty) {
-            data.mutation = [MutationKind.any];
+            // by default use the recommended operators
+            with (MutationKind) {
+                data.mutation = [lcr, lcrb, sdl, uoi, dcr];
+            }
         }
 
         compiler.extraFlags = compiler.extraFlags ~ args.find("--").drop(1).array();

--- a/plugin/mutate/source/dextool/plugin/mutate/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/type.d
@@ -13,8 +13,8 @@ import dextool.type : Path, AbsolutePath;
 
 /// The kind of mutation to perform
 enum MutationKind {
-    /// any kind of mutation
-    any,
+    /// all mutation operators are used
+    all,
     /// Relational operator replacement
     ror,
     /// Relational operator replacement for pointers

--- a/plugin/mutate/test/test_mutant_tester.d
+++ b/plugin/mutate/test/test_mutant_tester.d
@@ -728,21 +728,24 @@ class ShallKeepTheTestCaseResultsLinkedToMutantsWhenReAnalyzing : DatabaseFixtur
         db.updateMutation(MutationId(1), Mutation.Status.killed,
                 5.dur!"msecs", [TestCase("tc_1")]);
         // verify pre-condition that test cases exist in the DB
-        auto r0 = makeDextoolReport(testEnv, testData.dirName).addArg([
-                "--section", "tc_stat"
-                ]).run;
-        testConsecutiveSparseOrder!SubStr(["| 100        | 1     | tc_1     |"]).shouldBeIn(
-                r0.output);
+        auto r0 = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
+            .addArg(["--section", "tc_stat"])
+            .run;
+        testConsecutiveSparseOrder!SubStr(
+            ["| 100        | 1     | tc_1     |"])
+            .shouldBeIn(r0.output);
 
         // Act
         makeDextoolAnalyze(testEnv).addInputArg(programFile).run;
 
         // Assert that the test cases are still their
-        auto r1 = makeDextoolReport(testEnv, testData.dirName).addArg([
-                "--section", "tc_stat"
-                ]).run;
-        testConsecutiveSparseOrder!SubStr(["| 100        | 1     | tc_1     |"]).shouldBeIn(
-                r1.output);
+        auto r1 = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
+            .addArg(["--section", "tc_stat"])
+            .run;
+        testConsecutiveSparseOrder!SubStr(["| 100        | 1     | tc_1     |"])
+            .shouldBeIn(r1.output);
     }
 }
 
@@ -972,6 +975,7 @@ class ShallBeDeterministicPullRequestTestSequence : SimpleFixture {
             .args(["mutate"])
             .addArg(["test"])
             .addPostArg(["--db", (testEnv.outdir ~ defaultDb).toString])
+            .addPostArg(["--mutant", "all"])
             .addPostArg(["--build-cmd", compile_script])
             .addPostArg(["--test-cmd", "/bin/true"])
             .addPostArg(["--test-timeout", "10000"])

--- a/plugin/mutate/test/test_report.d
+++ b/plugin/mutate/test/test_report.d
@@ -62,6 +62,7 @@ unittest {
 
     // Act
     auto r = makeDextoolReport(testEnv, testData.dirName)
+        .addPostArg(["--mutant", "all"])
         .addArg(["--level", "alive"])
         .addArg(["--style", "markdown"])
         .run;
@@ -197,6 +198,7 @@ unittest {
 
     // Act
     auto r = makeDextoolReport(testEnv, testData.dirName)
+        .addPostArg(["--mutant", "all"])
         .addArg(["--section", "tc_stat"])
         .addArg(["--style", "plain"])
         .run;
@@ -230,6 +232,7 @@ unittest {
 
     // Act
     auto r = makeDextoolReport(testEnv, testData.dirName)
+        .addPostArg(["--mutant", "all"])
         .addArg(["--section", "tc_full_overlap"])
         .addArg(["--style", "plain"])
         .run;
@@ -266,6 +269,7 @@ unittest {
 
     // Act
     auto r = makeDextoolReport(testEnv, testData.dirName)
+        .addPostArg(["--mutant", "all"])
         .addArg(["--section", "tc_stat"])
         .addArg(["--style", "plain"])
         .addArg(["--section-tc_stat-num", "2"])
@@ -323,11 +327,13 @@ class ShallReportTestCasesThatHasKilledZeroMutants : SimpleAnalyzeFixture {
 
         // Act
         auto r = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "tc_killed_no_mutants"])
             .addArg(["--style", "plain"])
             .run;
 
         makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "tc_killed_no_mutants"])
             .addArg(["--style", "html"])
             .addArg(["--logdir", testEnv.outdir.toString])
@@ -396,6 +402,7 @@ class ShallReportAliveMutantsOnChangedLine : SimpleAnalyzeFixture {
         db.updateMutation(MutationId(1), Mutation.Status.alive, 5.dur!"msecs", null);
 
         auto r = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--style", "html"])
             .addArg(["--logdir", testEnv.outdir.toString])
             .addArg("--diff-from-stdin")
@@ -404,6 +411,7 @@ class ShallReportAliveMutantsOnChangedLine : SimpleAnalyzeFixture {
             .run;
 
         makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--style", "json"])
             .addArg(["--logdir", testEnv.outdir.toString])
             .addArg("--diff-from-stdin")
@@ -475,17 +483,20 @@ class ShallReportMutationScoreAdjustedByNoMut : LinesWithNoMut {
             db.updateMutation(MutationId(i), Mutation.Status.alive, 5.dur!"msecs", null);
 
         auto plain = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "summary"])
             .addArg(["--style", "plain"])
             .run;
 
         auto markdown = makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "summary"])
             .addArg(["--style", "markdown"])
             .run;
 
         // TODO how to verify this? arsd.dom?
         makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "summary"])
             .addArg(["--style", "html"])
             .addArg(["--logdir", testEnv.outdir.toString])
@@ -529,6 +540,7 @@ class ShallReportHtmlMutationScoreAdjustedByNoMut : LinesWithNoMut {
             db.updateMutation(MutationId(i), Mutation.Status.alive, 5.dur!"msecs", null);
 
         makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "summary"])
             .addArg(["--style", "html"])
             .addArg(["--logdir", testEnv.outdir.toString])
@@ -570,6 +582,7 @@ class ShallReportHtmlNoMutForMutantsInFileView : LinesWithNoMut {
             db.updateMutation(MutationId(i), Mutation.Status.alive, 5.dur!"msecs", null);
 
         makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
             .addArg(["--section", "summary"])
             .addArg(["--style", "html"])
             .addArg(["--logdir", testEnv.outdir.toString])
@@ -578,7 +591,6 @@ class ShallReportHtmlNoMutForMutantsInFileView : LinesWithNoMut {
         // this is a bit inprecies but there should be a couple, unknown the
         // number, of mutants without any metadata. Then there should be some
         // with nomut.
-        // dfmt off
         testConsecutiveSparseOrder!SubStr([
             "'meta' : ''",
             "'meta' : ''",
@@ -586,7 +598,6 @@ class ShallReportHtmlNoMutForMutantsInFileView : LinesWithNoMut {
             "'meta' : 'nomut'",
             "'meta' : 'nomut'",
             ]).shouldBeIn(File(buildPath(testEnv.outdir.toString, "html", "files", "build_plugin_mutate_plugin_testdata_report_nomut1.cpp.html")).byLineCopy.array);
-        // dfmt on
 }
 }
 
@@ -602,11 +613,12 @@ class ShallReportHtmlNoMutSummary : LinesWithNoMut {
         foreach (i; 15 .. 30)
             db.updateMutation(MutationId(i), Mutation.Status.alive, 5.dur!"msecs", null);
 
-        makeDextoolReport(testEnv, testData.dirName).addArg([
-                "--section", "summary"
-                ]).addArg(["--style", "html"]).addArg([
-                "--logdir", testEnv.outdir.toString
-                ]).run;
+        makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
+            .addArg(["--section", "summary"])
+            .addArg(["--style", "html"])
+            .addArg(["--logdir", testEnv.outdir.toString])
+            .run;
 
         // assert
         testConsecutiveSparseOrder!SubStr([
@@ -660,10 +672,12 @@ class ShallReportHtmlTestCaseSimilarity : LinesWithNoMut {
                 ]);
 
         // Act
-        makeDextoolReport(testEnv, testData.dirName).addArg(["--style", "html"])
-            .addArg(["--section", "tc_similarity"]).addArg([
-                    "--logdir", testEnv.outdir.toString
-                    ]).run;
+        makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
+            .addArg(["--style", "html"])
+            .addArg(["--section", "tc_similarity"])
+            .addArg(["--logdir", testEnv.outdir.toString])
+            .run;
 
         // Assert
         testConsecutiveSparseOrder!SubStr([
@@ -711,10 +725,12 @@ class ShallReportTestCaseUniqueness : LinesWithNoMut {
                 ]);
 
         // Act
-        makeDextoolReport(testEnv, testData.dirName).addArg(["--style", "html"])
-            .addArg(["--section", "tc_unique"]).addArg([
-                    "--logdir", testEnv.outdir.toString
-                    ]).run;
+        makeDextoolReport(testEnv, testData.dirName)
+            .addPostArg(["--mutant", "all"])
+            .addArg(["--style", "html"])
+            .addArg(["--section", "tc_unique"])
+            .addArg(["--logdir", testEnv.outdir.toString])
+            .run;
 
         // Assert
         testConsecutiveSparseOrder!SubStr([


### PR DESCRIPTION
This set the operators, when the user doesn't specify one, to those that we have found most useful.