### PR TITLE
mutate: fix gtest segfault detection

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
@@ -157,18 +157,6 @@ void builtin(DrainElement[] output,
             logger.warning(e.msg).collectException;
         }
     }
-
-    foreach (const p; tc_analyze_builtin) {
-        final switch (p) {
-        case TestCaseAnalyzeBuiltin.gtest:
-            gtest.finish(app);
-            break;
-        case TestCaseAnalyzeBuiltin.ctest:
-            break;
-        case TestCaseAnalyzeBuiltin.makefile:
-            break;
-        }
-    }
 }
 
 struct LineRange {


### PR DESCRIPTION
The previous implementation didn't work but wasn't detected because the
test case where a bit too simplistic.