### PR TITLE
mutate: more than one mutant can be added each loop thus missing the

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_schemata.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_schemata.d
@@ -206,7 +206,7 @@ struct SchematasRange {
                 // conservative to only allow up to 100 mutants per schemata.
                 // but it reduces the chance that one failing schemata is
                 // "fatal", loosing too many muntats.
-                if (index.inside(0, a.offset) || mutants.length == 100) {
+                if (index.inside(0, a.offset) || mutants.length >= 100) {
                     spillOver.put(a);
                 } else {
                     app.put(SchemataFragment(relp, a.offset, a.text));


### PR DESCRIPTION
exact limit.