### PR TITLE
mutate: change lcr and aor to improve compatibility with schemata

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/aor.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/aor.d
@@ -24,24 +24,19 @@ auto aorMutations(Kind operator) @safe pure nothrow {
 
     switch (operator) with (Mutation.Kind) {
     case Kind.OpAdd:
-        rval = Rval([aorMul, aorDiv, aorRem, aorSub],
-                [Mutation.Kind.aorLhs], [Mutation.Kind.aorRhs]);
+        rval = Rval([aorMul, aorDiv, aorRem, aorSub], null, null);
         break;
     case Kind.OpDiv:
-        rval = Rval([aorMul, aorRem, aorAdd, aorSub],
-                [Mutation.Kind.aorLhs], [Mutation.Kind.aorRhs]);
+        rval = Rval([aorMul, aorRem, aorAdd, aorSub], null, null);
         break;
     case Kind.OpMod:
-        rval = Rval([aorMul, aorDiv, aorAdd, aorSub],
-                [Mutation.Kind.aorLhs], [Mutation.Kind.aorRhs]);
+        rval = Rval([aorMul, aorDiv, aorAdd, aorSub], null, null);
         break;
     case Kind.OpMul:
-        rval = Rval([aorDiv, aorRem, aorAdd, aorSub],
-                [Mutation.Kind.aorLhs], [Mutation.Kind.aorRhs]);
+        rval = Rval([aorDiv, aorRem, aorAdd, aorSub], null, null);
         break;
     case Kind.OpSub:
-        rval = Rval([aorMul, aorDiv, aorRem, aorAdd],
-                [Mutation.Kind.aorLhs], [Mutation.Kind.aorRhs]);
+        rval = Rval([aorMul, aorDiv, aorRem, aorAdd], null, null);
         break;
     case Kind.OpAssignAdd:
         rval = Rval([aorDivAssign, aorRemAssign,

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcr.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/lcr.d
@@ -22,10 +22,10 @@ auto lcrMutations(Kind operator) {
 
     switch (operator) with (Mutation.Kind) {
     case Kind.OpAnd:
-        rval = Rval([lcrOr], [lcrTrue, lcrFalse], [lcrLhs], [lcrRhs]);
+        rval = Rval([lcrOr], [lcrTrue, lcrFalse], null, null);
         break;
     case Kind.OpOr:
-        rval = Rval([lcrAnd], [lcrTrue, lcrFalse], [lcrLhs], [lcrRhs]);
+        rval = Rval([lcrAnd], [lcrTrue, lcrFalse], null, null);
         break;
         // TODO: add assign
     default:

--- a/plugin/mutate/test/mutate_lcr.d
+++ b/plugin/mutate/test/mutate_lcr.d
@@ -30,11 +30,31 @@ unittest {
         "from '&&' to '||'",
         "from 'a && b' to 'true'",
         "from 'a && b' to 'false'",
-        "from '&& b' to ''",
-        "from 'a &&' to ''",
         "from '||' to '&&'",
         "from 'a || b' to 'true'",
         "from 'a || b' to 'false'",
+    ]).shouldBeIn(r.output);
+}
+
+@(testId ~ "shall produce all LCR delete mutations for primitive types")
+@Values("lcr_primitive.cpp", "lcr_overload.cpp", "lcr_in_ifstmt.cpp")
+@ShouldFail
+unittest {
+    mixin(envSetup(globalTestdir, No.setupEnv));
+    testEnv.outputSuffix(getValue!string);
+    testEnv.setupEnv;
+
+    makeDextoolAnalyze(testEnv)
+        .addInputArg(testData ~ getValue!string)
+        .run;
+    auto r = makeDextool(testEnv)
+        .addArg(["test"])
+        .addArg(["--mutant", "lcr"])
+        .run;
+
+    testAnyOrder!SubStr([
+        "from '&& b' to ''",
+        "from 'a &&' to ''",
         "from '|| b' to ''",
         "from 'a ||' to ''",
     ]).shouldBeIn(r.output);


### PR DESCRIPTION
removing lhs or rhs of these operators may change the expressions type
which lead to compilation errors when injected in the expression with
the ternery operator.