### PR TITLE
mutate: fix diff score

### DIFF
--- a/vendor/miniorm/source/miniorm/api.d
+++ b/vendor/miniorm/source/miniorm/api.d
@@ -467,9 +467,11 @@ SysTime fromSqLiteDateTime(string raw_dt) {
     }
 }
 
-string toSqliteDateTime(SysTime ts) {
+/// To ensure a consistency the time is always converted to UTC.
+string toSqliteDateTime(SysTime ts_) {
     import std.format;
 
+    auto ts = ts_.toUTC;
     return format("%04s-%02s-%02s %02s:%02s:%02s.%s", ts.year,
             cast(ushort) ts.month, ts.day, ts.hour, ts.minute, ts.second,
             ts.fracSecs.total!"msecs");


### PR DESCRIPTION
It wrongly calculated the score based on the affected files when it
should have been the uniquely killed mutants.