### PR TITLE
mutate: workaround that a schema that contains mutants isn't executed in

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -1670,7 +1670,8 @@ struct Database {
 
     MutationStatusId[] getSchemataMutants(const SchemataId id,
             const Mutation.Kind[] kinds, const Mutation.Status status) @trusted {
-        immutable sql = format!"SELECT t1.st_id
+        // TODO: DISTINCT should not be needed. Instead use e.g. a constraint on the table or something
+        immutable sql = format!"SELECT DISTINCT t1.st_id
             FROM %s t1, %s t2, %s t3
             WHERE
             t1.schem_id = :id AND


### PR DESCRIPTION
the test phase.
This is because the schema tables allow the same mutation status ID to
be added multiple times with a relation to the schema. The InjectBuilder
in turn then removes mutants if they occur multiple times. The result is
that all mutants are removed just before the schema is executed.