### PR TITLE
mutate: ensure a schema do not have duplicate mutation status IDs

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
@@ -421,6 +421,7 @@ struct MarkedMutantTbl {
 @TableName(schemataMutantTable)
 @TableForeignKey("st_id", KeyRef("mutation_status(id)"), KeyParam("ON DELETE CASCADE"))
 @TableForeignKey("schem_id", KeyRef("schemata(id)"), KeyParam("ON DELETE CASCADE"))
+@TableConstraint("unique_ UNIQUE (st_id, schem_id)")
 struct SchemataMutantTable {
     @ColumnName("st_id")
     long statusId;
@@ -1033,6 +1034,12 @@ void upgradeV19(ref Miniorm db) {
     db.run(format!"DROP TABLE %s"(schemataMutantTable));
 
     db.run(buildSchema!(SchemataTable, SchemataMutantTable, InvalidSchemataTable));
+}
+
+/// 2020-06-01
+void upgradeV20(ref Miniorm db) {
+    db.run(format!"DROP TABLE %s"(schemataMutantTable));
+    db.run(buildSchema!(SchemataMutantTable));
 }
 
 void replaceTbl(ref Miniorm db, string src, string dst) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -1762,7 +1762,7 @@ struct Database {
         }
 
         // relate mutants to this schemata.
-        db.run(insertOrReplace!SchemataMutantTable,
+        db.run(insertOrIgnore!SchemataMutantTable,
                 mutants.map!(a => SchemataMutantTable(cast(long) a, schemId)));
 
         return typeof(return)(schemId.SchemataId);


### PR DESCRIPTION
related to it.