### PR TITLE
mutate: to force testing of timeout mutants to stop as soon as possible

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/admin.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/admin.d
@@ -275,6 +275,7 @@ ExitStatusType stopTimeoutTest(ref Database db) @trusted nothrow {
         logger.info("Forcing the testing of timeout mutants to stop");
         auto t = db.transaction;
 
+        db.resetMutantTimeoutWorklist(Mutation.Status.timeout);
         db.clearMutantTimeoutWorklist;
 
         MutantTimeoutCtx ctx;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -1547,11 +1547,11 @@ struct Database {
     }
 
     /// Changes the status of mutants in the timeout worklist to unknown.
-    void resetMutantTimeoutWorklist() @trusted {
+    void resetMutantTimeoutWorklist(Mutation.Status toStatus) @trusted {
         immutable sql = format!"UPDATE %1$s SET status=:st WHERE id IN (SELECT id FROM %2$s)"(
                 mutationStatusTable, mutantTimeoutWorklistTable);
         auto stmt = db.prepare(sql);
-        stmt.get.bind(":st", cast(ubyte) Mutation.Status.unknown);
+        stmt.get.bind(":st", cast(ubyte) toStatus);
         stmt.get.execute;
     }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
@@ -238,7 +238,7 @@ struct TimeoutFsm {
     }
 
     void opCall(ResetWorkList) {
-        global.db.resetMutantTimeoutWorklist;
+        global.db.resetMutantTimeoutWorklist(Mutation.Status.unknown);
     }
 
     void opCall(UpdateCtx) {


### PR DESCRIPTION
the once in the worklist has to be changed back to timeout.