### PR TITLE
mutate: fix html colors

### DIFF
--- a/plugin/mutate/views/source.css
+++ b/plugin/mutate/views/source.css
@@ -5,13 +5,13 @@
 .status_alive {background-color: lightpink;}
 .status_killed {background-color: lightgreen;}
 .status_killedByCompiler {background-color: #eeeeee;}
-.status_timeout {background-color: limegreen;}
-.status_unknown {background-color: mistyrose;}
+.status_timeout {background-color: lightgreen;}
+.status_unknown {background-color: lightyellow;}
 .hover_alive {color: lightpink;}
 .hover_killed {color: lightgreen;}
 .hover_killedByCompiler {color: #eeeeee;}
-.hover_timeout {color: limegreen;}
-.hover_unknown {color: mistyrose;}
+.hover_timeout {color: lightgreen;}
+.hover_unknown {color: lightyellow;}
 .literal {color: darkred;}
 .keyword {color: blue;}
 .comment {color: grey;}


### PR DESCRIPTION
1) This fixes the problem that light pink (alive) vs mistyrose (unknown) can be easy to mix by mistake, by introducing a light yellow color for unknown.

2) It changes time-out mutants to use the same color brightness as killed mutants (light green), to reduce confusion.

![image](https://user-images.githubusercontent.com/5559216/89418090-e09c5d00-d72f-11ea-8e1f-ed11e75d0995.png)