### PR TITLE
mutate: refactor init file description

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -103,7 +103,7 @@ struct ArgParser {
         app.put("# number of threads to be used for analysis (default is the number of cores).");
         app.put("# threads = 1");
         app.put(null);
-        app.put("# remove files from the database that aren't found during analysis.");
+        app.put("# remove files from the database that are no longer found during analysis.");
         app.put(`# prune = true`);
         app.put(null);
         app.put("# maximum number of mutants per schema (zero means no limit).");
@@ -112,7 +112,7 @@ struct ArgParser {
 
         app.put("[database]");
         app.put(null);
-        app.put("# path (absolute or relative) where to store mutation statistics.");
+        app.put("# path (absolute or relative) where mutation statistics will be stored.");
         app.put(`# db = "dextool_mutate.sqlite3"`);
         app.put(null);
 
@@ -131,7 +131,7 @@ struct ArgParser {
 
         app.put("[compile_commands]");
         app.put(null);
-        app.put("# search for compile_commands.json in these path(s).");
+        app.put("# files and/or directories to look for compile_commands.json.");
         if (compileDb.dbs.length == 0)
             app.put(`# search_paths = ["./compile_commands.json"]`);
         else
@@ -146,25 +146,24 @@ struct ArgParser {
 
         app.put("[mutant_test]");
         app.put(null);
-        app.put("# (required) command(s) to test the application, for example:");
-        app.put(`# 1. ["test1.sh", "test2.sh"]`);
-        app.put(`# 2. [["test1.sh", "-x"], "test2.sh"]`);
-        app.put(`# test_cmd = ["./test.sh"]`);
+        app.put("# command to build the program **and** test suite.");
+        app.put(`build_cmd = ["./build.sh"]`);
         app.put(null);
-        app.put(`# find, recursively, all executables in the directory tree(s) and add them as test_cmds`);
-        app.put(`# use this as a convenience to specifying the binaries manually.`);
+        app.put("# at least one of test_cmd_dir (faster) or test_cmd (slower) needs to be specified.");
+        app.put(null);
+        app.put(`# path(s) to recursively look for test binaries to execute.`);
         app.put(`test_cmd_dir = ["./build/test"]`);
         app.put(null);
         app.put(`# flags to add to all executables found in test_cmd_dir.`);
         app.put(`# test_cmd_dir_flag = ["--gtest_filter", "-*foo"]`);
         app.put(null);
-        app.put("# timeout to use for the test suite.");
+        app.put("# command(s) to test the program.");
+        app.put(`# test_cmd = ["./test.sh"]`);
+        app.put(null);
+        app.put("# timeout to use for the test suite (by default a measurement-based heuristic will be used).");
         app.put(`# test_cmd_timeout = "1 hours 1 minutes 1 seconds 1 msecs"`);
         app.put(null);
-        app.put("# (required) command to build the application **and** test suite.");
-        app.put(`build_cmd = ["./build.sh"]`);
-        app.put(null);
-        app.put("# timeout to use when compiling the SUT and test suite (default: 30 minutes)");
+        app.put("# timeout to use when compiling the program and test suite (default: 30 minutes)");
         app.put(`# build_cmd_timeout = "1 hours 1 minutes 1 seconds 1 msecs"`);
         app.put(null);
         app.put("# program used to analyze the output from the test suite for test cases that killed the mutant");


### PR DESCRIPTION
Output when using this patch:

```
[workarea]

# base path (absolute or relative) to look for C/C++ files to mutate.
# root = "."

# files and/or directories (relative to root) to be the **only** sources to mutate.
# restrict = []

[analyze]

# files and/or directories (relative to root) to be excluded from analysis.
# exclude = []

# number of threads to be used for analysis (default is the number of cores).
# threads = 1

# remove files from the database that are no longer found during analysis.
# prune = true

# maximum number of mutants per schema (zero means no limit).
# mutants_per_schema = 100

[database]

# path (absolute or relative) where mutation statistics will be stored.
# db = "dextool_mutate.sqlite3"

[compiler]

# extra flags to pass on to the compiler such as the C++ standard.
# extra_flags = []

# force system includes to use -I instead of -isystem
# force_system_includes = true

# system include paths to use instead of the ones in compile_commands.json
# use_compiler_system_includes = "/path/to/c++"

[compile_commands]

# files and/or directories to look for compile_commands.json.
# search_paths = ["./compile_commands.json"]

# compile flags to remove when analyzing a file.
# filter = ["-c", "-o", "-m", "-nodevicelib", "-Waddr-space-convert", "-non-static", "-Bstatic", "-Bdynamic", "-Xbind-lazy", "-Xbind-now", "-f", "-static", "-shared", "-rdynamic", "-s", "-l", "-L", "-z", "-u", "-T", "-Xlinker", "-l", "-MT", "-MF", "-MD", "-MQ", "-MMD", "-MP", "-MG", "-E", "-cc1", "-S", "-M", "-MM", "-###"]

# number of compiler arguments to skip from the beginning (needed when the first argument is NOT a compiler but rather a wrapper).
# skip_compiler_args = 0

[mutant_test]

# command to build the program **and** test suite.
build_cmd = ["./build.sh"]

# at least one of test_cmd_dir (recommended) or test_cmd needs to be specified.

# path(s) to recursively look for test binaries to execute.
test_cmd_dir = ["./build/test"]

# flags to add to all executables found in test_cmd_dir.
# test_cmd_dir_flag = ["--gtest_filter", "-*foo"]

# command(s) to test the program.
# test_cmd = ["./test.sh"]

# timeout to use for the test suite (by default a measurement-based heuristic will be used).
# test_cmd_timeout = "1 hours 1 minutes 1 seconds 1 msecs"

# timeout to use when compiling the program and test suite (default: 30 minutes)
# build_cmd_timeout = "1 hours 1 minutes 1 seconds 1 msecs"

# program used to analyze the output from the test suite for test cases that killed the mutant
# analyze_cmd = "analyze.sh"

# built-in analyzer of output from testing frameworks to find failing test cases
# analyze_using_builtin = ["gtest", "ctest", "makefile"]

# determine in what order mutations are chosen
# order = "random"|"consecutive"

# how to behave when new test cases are found
# detected_new_test_case = "doNothing"|"resetAlive"

# how to behave when test cases are detected as having been removed
# should the test and the gathered statistics be removed too?
# detected_dropped_test_case = "doNothing"|"remove"

# how the oldest mutants should be treated.
# It is recommended to test them again.
# Because you may have changed the test suite so mutants that where previously killed by the test suite now survive.
# oldest_mutants = "nothing"|"test"

# how many of the oldest mutants to do the above with
# oldest_mutants_nr = 10

# number of threads to be used when running tests in parallel (default is the number of cores).
# parallel_test = 1

# stop executing tests as soon as a test command fails.
# This speed up the test phase but the report of test cases killing mutants is less accurate
use_early_stop = true

# reduce the compile and link time when testing mutants
use_schemata = true

# sanity check the schemata before it is used by executing the test cases
# it is a slowdown but nice robustness that is usually worth having
check_schemata = true

[report]

# default style to use
# style = "plain"|"markdown"|"compiler"|"json"|"csv"|"html"

[test_group]

# subgroups with a description and pattern. Example:
# [test_group.uc1]
# description = "use case 1"
# pattern = "uc_1.*"
# see for regex syntax: http://dlang.org/phobos/std_regex.html
```