### PR TITLE
mutate: refcount the AST to allow it to be released by to the GC earlier

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -493,6 +493,8 @@ struct Analyze {
 
         {
             auto schemas = toSchemata(ast, fio, codeMutants, conf.mutantsPerSchema);
+            ast.release;
+
             debug logger.trace(schemas);
             foreach (f; schemas.getSchematas.filter!(a => !(a.fragments.empty || a.mutants.empty))) {
                 const id = result.schematas.length;
@@ -500,8 +502,6 @@ struct Analyze {
                 result.schemataMutants[id] = f.mutants.map!(a => a.id).array;
                 result.schemataChecksum[id] = f.checksum;
             }
-
-            ast = typeof(ast).init;
         }
 
         result.mutationPoints = codeMutants.points.byKeyValue.map!(

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_clang.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_clang.d
@@ -18,6 +18,7 @@ import std.meta : AliasSeq;
 import std.typecons : Nullable, scoped;
 
 import automem : vector, Vector;
+import my.gc.refc : RefCounted;
 
 import clang.Cursor : Cursor;
 import clang.Eval : Eval;
@@ -42,7 +43,7 @@ alias accept = dextool.plugin.mutate.backend.analyze.extensions.accept;
 
 /** Translate a clang AST to a mutation AST.
  */
-analyze.Ast toMutateAst(const Cursor root, FilesysIO fio) @trusted {
+RefCounted!(analyze.Ast) toMutateAst(const Cursor root, FilesysIO fio) @trusted {
     import cpptooling.analyzer.clang.ast : ClangAST;
 
     auto svisitor = scoped!BaseVisitor(fio);
@@ -373,12 +374,13 @@ final class BaseVisitor : ExtendedVisitor {
     /// in any of them.
     BlackList blacklist;
 
-    analyze.Ast ast;
+    RefCounted!(analyze.Ast) ast;
 
     FilesysIO fio;
 
     this(FilesysIO fio) nothrow {
         this.fio = fio;
+        this.ast = analyze.Ast.init;
     }
 
     /// Returns: if the previous nodes is a CXCursorKind `k`.


### PR DESCRIPTION
and make it cheaper to share internally.