### PR TITLE
mutate: fix default config and value for compile_commands.json

### DIFF
--- a/libs/cpptooling/source/cpptooling/analyzer/clang/check_parse_result.d
+++ b/libs/cpptooling/source/cpptooling/analyzer/clang/check_parse_result.d
@@ -15,7 +15,7 @@ import clang.TranslationUnit : TranslationUnit;
  *
  * Returns: True if errors where found.
  */
-bool hasParseErrors(ref TranslationUnit tu) @safe {
+bool hasParseErrors(ref TranslationUnit tu) @trusted {
     import clang.c.Index : CXDiagnosticSeverity;
 
     if (!tu.isValid)
@@ -23,58 +23,51 @@ bool hasParseErrors(ref TranslationUnit tu) @safe {
 
     auto dia = tu.diagnostics;
 
-    auto rval = () @trusted {
-        foreach (diag; dia) {
-            auto severity = diag.severity;
+    foreach (diag; dia) {
+        auto severity = diag.severity;
 
-            final switch (severity) with (CXDiagnosticSeverity) {
-            case ignored:
-            case note:
-            case warning:
-                break;
-            case error:
-            case fatal:
-                return true;
-            }
+        final switch (severity) with (CXDiagnosticSeverity) {
+        case ignored:
+        case note:
+        case warning:
+            break;
+        case error:
+        case fatal:
+            return true;
         }
-        return false;
-    }();
-
-    return rval;
+    }
+    return false;
 }
 
 /** Log diagnostic error messages to std.logger.
  *
  * TODO Change to a template with a sink as parameter.
  */
-void logDiagnostic(ref TranslationUnit tu) @safe {
+void logDiagnostic(ref TranslationUnit tu) @trusted {
     import logger = std.experimental.logger;
-
     import clang.c.Index : CXDiagnosticSeverity;
 
     auto dia = tu.diagnostics;
 
-    () @trusted {
-        foreach (diag; dia) {
-            auto severity = diag.severity;
+    foreach (diag; dia) {
+        auto severity = diag.severity;
 
-            final switch (severity) with (CXDiagnosticSeverity) {
-            case ignored:
-                logger.info(diag.format);
-                break;
-            case note:
-                logger.info(diag.format);
-                break;
-            case warning:
-                logger.warning(diag.format);
-                break;
-            case error:
-                logger.error(diag.format);
-                break;
-            case fatal:
-                logger.error(diag.format);
-                break;
-            }
+        final switch (severity) with (CXDiagnosticSeverity) {
+        case ignored:
+            logger.info(diag.format);
+            break;
+        case note:
+            logger.info(diag.format);
+            break;
+        case warning:
+            logger.warning(diag.format);
+            break;
+        case error:
+            logger.error(diag.format);
+            break;
+        case fatal:
+            logger.error(diag.format);
+            break;
         }
-    }();
+    }
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -135,7 +135,7 @@ struct ArgParser {
         app.put(null);
         app.put("# files and/or directories to look for compile_commands.json.");
         if (compileDb.dbs.length == 0)
-            app.put(`# search_paths = ["./compile_commands.json"]`);
+            app.put(`search_paths = ["./compile_commands.json"]`);
         else
             app.put(format("search_paths = %s", compileDb.rawDbs));
         app.put(null);
@@ -527,10 +527,11 @@ struct ArgParser {
     }
 }
 
-/// Update the config from the users input.
+/// Replace the config from the users input.
 void updateCompileDb(ref ConfigCompileDb db, string[] compile_dbs) {
     if (compile_dbs.length != 0)
         db.rawDbs = compile_dbs;
+
     db.dbs = db.rawDbs
         .filter!(a => a.length != 0)
         .map!(a => Path(a).AbsolutePath)


### PR DESCRIPTION
the default should not be commented out because the normal case is to use a compile_commands.json