### PR TITLE
mutate: fix HTML and CVS report by printing mutation IDs as only their

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/compiler.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/compiler.d
@@ -78,7 +78,7 @@ import dextool.plugin.mutate.type : MutationKind, ReportLevel;
                 .begin("%s: replace '%s' with '%s'", r.mutation.kind.toUser,
                        window(mut_txt.original, windowSize),
                        window(mut_txt.mutation, windowSize))
-                .note("status:%s id:%s", r.mutation.status, r.id);
+                .note("status:%s id:%s", r.mutation.status, r.id.get);
 
             if (mut_txt.original.length > windowSize)
                 b = b.note("replace '%s'", mut_txt.original);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/csv.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/csv.d
@@ -77,7 +77,7 @@ final class ReportCSV : ReportEvent {
             auto desc = format(`'%s' to '%s'`, toField(mut_txt.original,
                     textualDescriptionLen), toField(mut_txt.mutation, textualDescriptionLen));
             auto loc = format("%s:%s:%s", r.file, r.sloc.line, r.sloc.column);
-            writer.writeCSV(r.id, r.mutation.kind.toUser, desc, loc, "");
+            writer.writeCSV(r.id.get, r.mutation.kind.toUser, desc, loc, "");
         }
 
         try {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_long_term_view.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_long_term_view.d
@@ -60,7 +60,7 @@ void toHtml(const MutantSample mut_sample, Element root) {
             auto r = tbl.appendRow();
             r.addChild("td").addChild("a", format("%s:%s", mut.file,
                     mut.sloc.line)).href = format("%s#%s", buildPath(htmlFileDir,
-                    pathToHtmlLink(mut.file)), mut.id);
+                    pathToHtmlLink(mut.file)), mut.id.get);
             r.addChild("td", mutst.added.isNull ? "unknown" : mutst.added.get.toString);
             r.addChild("td", mutst.updated.toString);
             r.addChild("td", format("%s times", mutst.testCnt));
@@ -79,7 +79,7 @@ void toHtml(const MutantSample mut_sample, Element root) {
             auto r = tbl.appendRow();
             r.addChild("td").addChild("a", format("%s:%s", mut.file,
                     mut.sloc.line)).href = format("%s#%s", buildPath(htmlFileDir,
-                    pathToHtmlLink(mut.file)), mut.id);
+                    pathToHtmlLink(mut.file)), mut.id.get);
             r.addChild("td", mutst.updated.toString);
         }
     }


### PR DESCRIPTION
number.