### PR TITLE
mutate: calculate the mean for each day

### DIFF
--- a/plugin/mutate/ut_main.d
+++ b/plugin/mutate/ut_main.d
@@ -14,6 +14,7 @@ int main(string[] args) {
                           "dextool.plugin.mutate.backend.analyze.pass_clang",
                           "dextool.plugin.mutate.backend.analyze.pass_schemata",
                           "dextool.plugin.mutate.backend.diff_parser",
+                          "dextool.plugin.mutate.backend.report.analyzers",
                           "dextool.plugin.mutate.backend.report.html",
                           "dextool.plugin.mutate.backend.test_mutant.common",
                           "dextool.plugin.mutate.backend.test_mutant.ctest_post_analyze",


### PR DESCRIPTION
this is to help a team earlier catch a change in the mutation score.
Without this it is discovered at the earliest the day after.