### PR TITLE
mutate: fix build_cmd parse error

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/common.d
@@ -437,6 +437,7 @@ CompileResult compile(ShellCommand cmd, Duration timeout, bool printToStdout = f
         }
     } catch (Exception e) {
         logger.warning("Unknown error when executing the build command").collectException;
+        logger.warning(cmd.value).collectException;
         logger.warning(e.msg).collectException;
         return CompileResult(Mutation.Status.unknown);
     }

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -376,13 +376,14 @@ struct ArgParser {
             if (maxAlive > 0)
                 mutationTest.maxAlive = maxAlive;
             if (mutationTester.length != 0)
-                mutationTest.mutationTester = mutationTester.map!(a => ShellCommand.fromString(a))
-                    .array;
+                mutationTest.mutationTester = mutationTester.map!(a => ShellCommand([
+                            a
+                        ])).array;
             if (mutationCompile.length != 0)
-                mutationTest.mutationCompile = ShellCommand.fromString(mutationCompile);
+                mutationTest.mutationCompile = ShellCommand([mutationCompile]);
             if (mutationTestCaseAnalyze.length != 0)
                 mutationTest.mutationTestCaseAnalyze = mutationTestCaseAnalyze.map!(
-                        a => ShellCommand.fromString(a)).array;
+                        a => ShellCommand([a])).array;
             if (mutationTesterRuntime != 0)
                 mutationTest.mutationTesterRuntime = mutationTesterRuntime.dur!"msecs";
             if (!maxRuntime.empty)
@@ -649,7 +650,7 @@ ArgParser loadConfig(ArgParser rval, ref TOMLDocument doc) @trusted {
 
     static ShellCommand toShellCommand(ref TOMLValue v, string errorMsg) {
         if (v.type == TOML_TYPE.STRING) {
-            return ShellCommand.fromString(v.str);
+            return ShellCommand([v.str]);
         } else if (v.type == TOML_TYPE.ARRAY) {
             return ShellCommand(v.array.map!(a => a.str).array);
         }
@@ -661,7 +662,7 @@ ArgParser loadConfig(ArgParser rval, ref TOMLDocument doc) @trusted {
         import std.format : format;
 
         if (v.type == TOML_TYPE.STRING) {
-            return [ShellCommand.fromString(v.str)];
+            return [ShellCommand([v.str])];
         } else if (v.type == TOML_TYPE.ARRAY) {
             return v.array.map!(a => toShellCommand(a,
                     format!"%s: failed to parse as an array"(errorMsg))).array;

--- a/plugin/mutate/source/dextool/plugin/mutate/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/type.d
@@ -165,15 +165,6 @@ struct ShellCommand {
 
     string[] value;
 
-    /// Split a user string by the whitespace to create an command+argument.
-    static ShellCommand fromString(string cmd) {
-        import std.uni : isWhite;
-        import std.array : split;
-
-        string[] args = cmd.split!isWhite;
-        return ShellCommand(args);
-    }
-
     bool empty() @safe pure nothrow const @nogc {
         return value.length == 0;
     }


### PR DESCRIPTION
A string where split by whitespace into an array and they executed as a
command. This obviously failed.