### PR TITLE
mutate: only instrument root with coverage runtime

### DIFF
--- a/plugin/mutate/data/coverage_mmap.c
+++ b/plugin/mutate/data/coverage_mmap.c
@@ -11,7 +11,7 @@
 static char* gDEXTOOL_COVMAP;
 static int gDEXTOOL_COVMAP_FD;
 
-__attribute__((constructor)) static void dextool_init_covmap(void) {
+__attribute__((constructor, weak)) void dextool_init_covmap__(void) {
     gDEXTOOL_COVMAP = 0;
     const char* cov_map_file = getenv("DEXTOOL_COVMAP");
     if (cov_map_file == NULL)
@@ -22,7 +22,7 @@ __attribute__((constructor)) static void dextool_init_covmap(void) {
     struct stat sb;
     if (fstat(fd, &sb) == -1)
         return;
-    char* addr = (char*) mmap(NULL, sb.st_size, PROT_WRITE, MAP_SHARED, fd, 0);
+    char* addr = (char*)mmap(NULL, sb.st_size, PROT_WRITE, MAP_SHARED, fd, 0);
     if (addr == MAP_FAILED)
         return;
     gDEXTOOL_COVMAP = addr;
@@ -30,7 +30,7 @@ __attribute__((constructor)) static void dextool_init_covmap(void) {
     *(gDEXTOOL_COVMAP) = 1; // successfully initialized
 }
 
-static void dextool_cov(unsigned int x) {
+__attribute__((weak)) void dextool_cov__(unsigned int x) {
     if (gDEXTOOL_COVMAP == NULL)
         return;
     *(gDEXTOOL_COVMAP + x) = 1;

--- a/plugin/mutate/data/coverage_mmap.h
+++ b/plugin/mutate/data/coverage_mmap.h
@@ -1,0 +1,6 @@
+#ifndef DEXTOOL_MUTANT_COV_INCL_GUARD
+#define DEXTOOL_MUTANT_COV_INCL_GUARD
+
+extern void dextool_cov__(unsigned int x);
+
+#endif /* DEXTOOL_MUTANT_COV_INCL_GUARD */

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/package.d
@@ -298,7 +298,9 @@ void storeActor(const AbsolutePath dbPath, scope shared FilesysIO fioShared,
             }
         }
 
-        void save(immutable Analyze.Result result) {
+        void save(immutable Analyze.Result result_) {
+            auto result = cast() result_;
+
             // mark files that have an unchanged checksum as "already saved"
             foreach (f; result.idFile
                     .byKey
@@ -324,7 +326,7 @@ void storeActor(const AbsolutePath dbPath, scope shared FilesysIO fioShared,
                     const relp = fio.toRelativeRoot(f);
                     db.removeFile(relp);
                     const info = result.infoId[result.idFile[f]];
-                    db.put(relp, info.checksum, info.language);
+                    db.put(relp, info.checksum, info.language, f in result.isRoot);
                     savedFiles.add(f);
                 }
                 db.put(app.data, fio.getOutputDir);
@@ -629,6 +631,8 @@ struct Analyze {
             return;
         }
 
+        result.isRoot.add(checked_in_file);
+
         auto ast = toMutateAst(tu.cursor, fio);
         debug logger.trace(ast);
 
@@ -721,6 +725,8 @@ struct Analyze {
             Checksum checksum;
             Language language;
         }
+
+        Set!AbsolutePath isRoot;
 
         /// The key is the ID from idFile.
         FileInfo[LocalFileId] infoId;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/resource.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/resource.d
@@ -77,6 +77,10 @@ string schemataHeader() {
     return readData("schemata_header.c");
 }
 
-string coverageMmapHdr() {
+string coverageMapHdr() {
+    return readData("coverage_mmap.h");
+}
+
+string coverageMapImpl() {
     return readData("coverage_mmap.c");
 }

--- a/plugin/mutate/test/test_covmap.cpp
+++ b/plugin/mutate/test/test_covmap.cpp
@@ -65,11 +65,11 @@ void test_write() {
     int fd = setup_covmap_file(dummy);
 
     msg("Let init run");
-    dextool_init_covmap();
+    dextool_init_covmap__();
     assert(gDEXTOOL_COVMAP != 0);
 
     msg("Use instrument function");
-    dextool_cov(1);
+    dextool_cov__(1);
 
     dextool_deinit_covmap();
 }
@@ -84,13 +84,13 @@ void test_read_write() {
     int fd = setup_covmap_file(dummy);
 
     msg("Let init run");
-    dextool_init_covmap();
+    dextool_init_covmap__();
     assert(gDEXTOOL_COVMAP != 0);
 
     msg("Use instrument function");
-    dextool_cov(1);
-    dextool_cov(3);
-    dextool_cov(5);
+    dextool_cov__(1);
+    dextool_cov__(3);
+    dextool_cov__(5);
 
     dextool_deinit_covmap();
 


### PR DESCRIPTION
This make it possible to mark a file as a root. It is those that are
analyzed which mean they come from e.g. a compile_commands.json.