### PR TITLE
mutate: remove DCR for case branches

### DIFF
--- a/plugin/mutate/doc/design/mutations.md
+++ b/plugin/mutate/doc/design/mutations.md
@@ -434,53 +434,6 @@ As discussed in [@thesis1, p. 20] the CC criteria is simulated by replacing
 clauses with `true` or `false`.  See [@subsumeCondMutTesting] for further
 discussions.
 
-### Case Deletion
-
-This is only needed for switch statements.
-It *deactivates* the functionality in the case branch in a switch statement.
-
-It is **more** equivalent to the DCC mutation for predicates (decision) that is
-set to *false* than using a bomb for the branch because deleting the
-functionality requires the test suite to *test* the side effect to be able to
-kill the mutant.  It isn't enough to *visit* the branch which is the case for a
-bomb.
-
-Motivation why it is equivalent.
-
-Consider the following switch statement:
-```cpp
-switch (x) {
-case A: y = 1; break;
-case B: y = 2; break;
-default: y = 3; break;
-}
-```
-
-It can be rewritten as:
-```cpp
-if (x == A) { y = 1; }
-else if (x == B) { y = 2; }
-else { y = 3; }
-```
-
-A decision mutation of the first branch is equivalent to replacement of `x == A` with `true`/`false`.
-```cpp
-if (false) { y = 1; }
-else if (x == B) { y = 2; }
-else { y = 3; }
-```
-
-Note that when it is set to `false` it is equivalent to *never* being taken.
-It is thus equivalent to the rewrite:
-```cpp
-if (x == B) { y = 2; }
-else { y = 3; }
-```
-
-The branch is deleted.
-
-Thus `false` is equivalent to statement deletion of the branch content.
-
 ### DCR for Bool Function {id="design-mutation_dcr-bool_func"}
 
 [partof](#design-mutation_dcr)

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_mutant.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_mutant.d
@@ -632,13 +632,7 @@ class MutantVisitor : DepthFirstVisitor {
         // only case statements have an inside. pretty bad "detection" but
         // works for now.
         if (n.inside !is null) {
-            const canRemove = sdlBlock(n.inside, stmtDelMutations(n.kind));
-
-            // removing the whole branch because then e.g. a switch-block would
-            // jump to the default branch. It becomes "more" predictable what
-            // happens compared to "falling through to the next case".
-            put(ast.location(n.inside), dcrMutations(DcrInfo(n.kind,
-                    ast.type(n), canRemove)), n.blacklist);
+            sdlBlock(n.inside, stmtDelMutations(n.kind));
         }
 
         accept(n, this);
@@ -750,14 +744,12 @@ class MutantVisitor : DepthFirstVisitor {
         }
     }
 
-    private bool sdlBlock(T)(T n, Mutation.Kind[] op) @trusted {
+    private void sdlBlock(T)(T n, Mutation.Kind[] op) @trusted {
         auto sdlAnalyze = scoped!DeleteBlockVisitor(ast);
         sdlAnalyze.startVisit(n);
 
         if (sdlAnalyze.canRemove)
             put(sdlAnalyze.loc, op, n.blacklist);
-
-        return sdlAnalyze.canRemove;
     }
 }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/dcr.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/dcr.d
@@ -56,10 +56,6 @@ Mutation.Kind[] dcrMutations(DcrInfo info) @safe {
                 && info.ty.kind.among(TypeKind.boolean, TypeKind.discrete))
             rval = [dcrTrue, dcrFalse];
         break;
-    case Kind.Branch:
-        if (info.canRemoveBranch)
-            rval = [dcrCaseDel];
-        break;
     case Kind.Return:
         if (info.ty !is null
                 && info.ty.kind == TypeKind.boolean)
@@ -75,8 +71,6 @@ immutable Mutation.Kind[] dcrMutationsAll;
 
 shared static this() {
     with (Mutation.Kind) {
-        dcrMutationsAll = [
-            dcrTrue, dcrFalse, dcrReturnTrue, dcrReturnFalse, dcrCaseDel
-        ];
+        dcrMutationsAll = [dcrTrue, dcrFalse, dcrReturnTrue, dcrReturnFalse];
     }
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
@@ -208,7 +208,7 @@ struct Mutation {
         dcrFalse,
         dcrBomb, // unused
         /// Decision/Condition Requirement
-        dcrCaseDel,
+        dcrCaseDel, // unused
         /// Relational operator replacement for pointers
         rorpLT,
         rorpLE,

--- a/plugin/mutate/test/test_mutant_tester.d
+++ b/plugin/mutate/test/test_mutant_tester.d
@@ -966,10 +966,7 @@ class ShallTestMutantsOnSpecifiedLines : SimpleFixture {
             .run;
         // dfmt on
 
-        testConsecutiveSparseOrder!Re([
-                `.*Found . mutant.*program.cpp:13`,
-                `.*Found . mutant.*program.cpp:15`
-                ]).shouldBeIn(r.output);
+        testConsecutiveSparseOrder!Re([`.*Found . mutant.*program.cpp:13`,]).shouldBeIn(r.output);
         testAnyOrder!Re([`from 'return true' to 'return false'`,]).shouldBeIn(r.output);
     }
 


### PR DESCRIPTION
it is equivalent with SDL of case branches thus this is an unnecessary
overlap. Lets keep DCR focused on only boolean expressions.