### PR TITLE
mutate: change html code comments to 100% width

### DIFF
--- a/plugin/mutate/data/source.css
+++ b/plugin/mutate/data/source.css
@@ -125,7 +125,6 @@ span.xx_label {
 }
 #locs {
     display: block;
-    width: 60%;
 }
 #locs  tr{
     display: block;

--- a/plugin/mutate/data/source.js
+++ b/plugin/mutate/data/source.js
@@ -46,7 +46,6 @@ function init() {
     init_legend();
     on_window_resize();
     var locs_table = document.getElementById("locs");
-    locs_table.style.width = "60%";
     var locs = document.getElementsByClassName('loc');
     for (var i=0; i<locs.length; i++){
         locs[i].addEventListener('wheel',


### PR DESCRIPTION
fixes code comments causing a line-break at 60% of the window width
this was proabably made to make the "killing test case info box" be 60%,
but 100% width for that box should not be causing any problems.