### PR TITLE
fix html line-break and padding between code lines

### DIFF
--- a/plugin/mutate/data/source.css
+++ b/plugin/mutate/data/source.css
@@ -125,6 +125,7 @@ span.xx_label {
 }
 #locs {
     display: block;
+    width: max-content;
 }
 #locs  tr{
     display: block;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
@@ -809,7 +809,7 @@ void generateFile(ref Database db, ref FileCtx ctx) @trusted {
     }
 
     auto root = ctx.doc.mainBody;
-    auto lines = root.addChild("table").setAttribute("id", "locs");
+    auto lines = root.addChild("table").setAttribute("id", "locs").setAttribute("cellpadding", "0");
     auto line = lines.addChild("tr").addChild("td").setAttribute("id", "loc-1");
     line.addClass("loc");
 


### PR DESCRIPTION
Example output:
![image](https://user-images.githubusercontent.com/5559216/109002148-95727900-7684-11eb-83e1-7105582facf2.png)

(For example line 90 does not break)