### PR TITLE
mutate: remove returTrue/false for dcr

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_mutant.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_mutant.d
@@ -446,8 +446,7 @@ class MutantVisitor : DepthFirstVisitor {
         // TODO: is this needed? I do not think so considering the rest of the
         // code.
 
-        if (isParent(Kind.Function) && ast.type(n) is null
-                && !isParent(Kind.Return) && isDirectParent(Kind.Block)) {
+        if (isParent(Kind.Function) && !isParent(Kind.Return) && isDirectParent(Kind.Block)) {
             // the check for Return blocks all SDL when an exception is thrown.
             //
             // the check isDirectParent(Kind.Block) is to only delete function
@@ -460,6 +459,10 @@ class MutantVisitor : DepthFirstVisitor {
             auto loc = ast.location(n);
             put(loc, stmtDelMutations(n.kind), n.blacklist);
         }
+        if (isDirectParent(Kind.Return) && isParentBoolFunc) {
+            auto loc = ast.location(n);
+            put(loc, dcrMutations(DcrInfo(n.kind, ast.type(n))), n.blacklist);
+        }
 
         // should call visitOp
         accept(n, this);
@@ -467,15 +470,13 @@ class MutantVisitor : DepthFirstVisitor {
 
     override void visit(Return n) {
         auto ty = closestFuncType;
-        auto loc = ast.location(n);
 
         if (ty !is null && ty.kind == TypeKind.top) {
+            auto loc = ast.location(n);
             // only function with return type void (top, no type) can be
             // deleted without introducing undefined behavior.
             put(loc, stmtDelMutations(n.kind), n.blacklist);
         }
-
-        put(loc, dcrMutations(DcrInfo(n.kind, ty)), n.blacklist);
 
         accept(n, this);
     }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/dcr.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/mutation_type/dcr.d
@@ -58,11 +58,6 @@ Mutation.Kind[] dcrMutations(DcrInfo info) @safe {
                 && info.ty.kind.among(TypeKind.boolean, TypeKind.discrete))
             rval = [dcrTrue, dcrFalse];
         break;
-    case Kind.Return:
-        if (info.ty !is null
-                && info.ty.kind == TypeKind.boolean)
-            rval = [dcrReturnTrue, dcrReturnFalse];
-        break;
     default:
     }
 
@@ -73,6 +68,6 @@ immutable Mutation.Kind[] dcrMutationsAll;
 
 shared static this() {
     with (Mutation.Kind) {
-        dcrMutationsAll = [dcrTrue, dcrFalse, dcrReturnTrue, dcrReturnFalse];
+        dcrMutationsAll = [dcrTrue, dcrFalse];
     }
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/type.d
@@ -234,8 +234,8 @@ struct Mutation {
         // uoi
         uoiDel,
         // dcr for return types
-        dcrReturnTrue,
-        dcrReturnFalse,
+        dcrReturnTrue, // unused
+        dcrReturnFalse, // unused
         // aors variant
         aorsMul,
         aorsDiv,

--- a/plugin/mutate/test/mutate_dcr.d
+++ b/plugin/mutate/test/mutate_dcr.d
@@ -133,11 +133,11 @@ unittest {
         .addArg(["--mutant", "dcr"])
         .run;
     testConsecutiveSparseOrder!SubStr([
-        "from 'return false' to 'return true'",
-        "from 'return true' to 'return false'",
-        "from 'return false' to 'return true'",
-        "from 'return false' to 'return true'",
-        "from 'return true' to 'return false'",
+        "from 'false' to 'true'",
+        "from 'true' to 'false'",
+        "from 'false' to 'true'",
+        "from 'false' to 'true'",
+        "from 'true' to 'false'",
     ]).shouldBeIn(r.output);
 }
 
@@ -169,8 +169,8 @@ unittest {
         .addArg(["--mutant", "dcr"])
         .run;
     testAnyOrder!SubStr([
-        "from 'return fun(x)' to 'return true'",
-        "from 'return fun(x)' to 'return false'",
+        "from 'fun(x)' to 'true'",
+        "from 'fun(x)' to 'false'",
     ]).shouldBeIn(r.output);
 }
 

--- a/plugin/mutate/test/test_analyzer.d
+++ b/plugin/mutate/test/test_analyzer.d
@@ -69,8 +69,6 @@ unittest {
     testAnyOrder!Re([
         `.*4.*dcrTrue`,
         `.*10.*dcrFalse`,
-        `.*4.*dcrReturnTrue`,
-        `.*10.*dcrReturnFalse`,
     ]).shouldBeIn(r.output);
 }
 

--- a/plugin/mutate/test/test_mutant_tester.d
+++ b/plugin/mutate/test/test_mutant_tester.d
@@ -907,7 +907,7 @@ class ShallTestMutantsOnSpecifiedLines : SimpleFixture {
         // dfmt on
 
         testConsecutiveSparseOrder!Re([`.*Found . mutant.*program.cpp:13`,]).shouldBeIn(r.output);
-        testAnyOrder!Re([`from 'return true' to 'return false'`,]).shouldBeIn(r.output);
+        testAnyOrder!Re([`from 'true' to 'false'`,]).shouldBeIn(r.output);
     }
 
     override string programFile() {
@@ -943,9 +943,7 @@ class ShallTestMutantsInDiff : SimpleFixture {
         testConsecutiveSparseOrder!Re([
                 `.*Found . mutant.*dcr_dc_switch1.cpp:11`,
                 ]).shouldBeIn(r.output);
-        testAnyOrder!Re([
-                `info:.*from 'return false' to 'return true'`, `info:.*killed`,
-                ]).shouldBeIn(r.output);
+        testAnyOrder!Re([`info:.*from 'false' to 'true'`, `info:.*killed`,]).shouldBeIn(r.output);
     }
 
     override string programFile() {


### PR DESCRIPTION
It is redundant because the expr will be mutated.