### PR TITLE
mutate: enable schematas in ternery ops

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_clang.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_clang.d
@@ -905,12 +905,7 @@ final class BaseVisitor : ExtendedVisitor {
     }
 
     override void visit(const ConditionalOperator v) {
-        // ternery operator. It is hard to create a schema that have the
-        // correct type on both rhs and lhs. for now just block scheman inside
-        // ternery.
-        auto n = ast.make!(analyze.Poision);
-        n.schemaBlacklist = true;
-        pushStack(n, v);
+        mixin(mixinNodeLog!());
         v.accept(this);
     }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_schemata.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/analyze/pass_schemata.d
@@ -566,7 +566,7 @@ class CppSchemataVisitor : DepthFirstVisitor {
     }
 
     private void visitCondition(T)(T n) @trusted {
-        if (!saveFragment || n.blacklist || n.schemaBlacklist)
+        if (!saveFragment || n.schemaBlacklist)
             return;
 
         // The schematas from the code below are only needed for e.g. function
@@ -595,7 +595,7 @@ class CppSchemataVisitor : DepthFirstVisitor {
     }
 
     private void visitBlock(T)(T n, bool requireSyntaxBlock = false) {
-        if (!saveFragment || n.blacklist || n.schemaBlacklist)
+        if (!saveFragment || n.schemaBlacklist)
             return;
 
         auto loc = ast.location(n);
@@ -630,8 +630,7 @@ class CppSchemataVisitor : DepthFirstVisitor {
     }
 
     private void visitUnaryOp(T)(T n) {
-        if (!saveFragment || n.blacklist || n.schemaBlacklist
-                || n.operator.blacklist || n.operator.schemaBlacklist)
+        if (!saveFragment || n.schemaBlacklist || n.operator.schemaBlacklist)
             return;
 
         auto loc = ast.location(n);
@@ -785,7 +784,7 @@ class BinaryOpVisitor : DepthFirstVisitor {
     }
 
     private void visitBinaryOp(T)(T n) {
-        if (n.blacklist || n.schemaBlacklist || n.operator.blacklist || n.operator.schemaBlacklist)
+        if (n.schemaBlacklist || n.operator.schemaBlacklist)
             return;
 
         auto locExpr = ast.location(n);

--- a/plugin/mutate/test/test_schemata.d
+++ b/plugin/mutate/test/test_schemata.d
@@ -40,7 +40,7 @@ class ShallRunAorSchema : SchemataFixutre {
     }
 }
 
-class ShallUseSchemataSanityCheck : SchemataFixutre {
+class ShallUseSchemaSanityCheck : SchemataFixutre {
     override string programFile() {
         return (testData ~ "simple_schemata.cpp").toString;
     }
@@ -137,7 +137,7 @@ class ShallRemoveParenthesisBalanced : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataForOverload : SchemataFixutre {
+class ShallGenerateValidSchemaForOverload : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_op_overload.cpp").toString;
     }
@@ -158,7 +158,7 @@ class ShallGenerateValidSchemataForOverload : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataForNestedIf : SchemataFixutre {
+class ShallGenerateValidSchemaForNestedIf : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_nested_if.cpp").toString;
     }
@@ -177,7 +177,7 @@ class ShallGenerateValidSchemataForNestedIf : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataForEnableIf : SchemataFixutre {
+class ShallGenerateValidSchemaForEnableIf : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_enableif.cpp").toString;
     }
@@ -202,7 +202,7 @@ g++ -std=c++14 %s -o %s
     }
 }
 
-class ShallGenerateValidSchemataForPtr : SchemataFixutre {
+class ShallGenerateValidSchemaForPtr : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_aor.cpp").toString;
     }
@@ -220,7 +220,7 @@ class ShallGenerateValidSchemataForPtr : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataForConstexpr : SchemataFixutre {
+class ShallGenerateValidSchemaForConstexpr : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_constexpr.cpp").toString;
     }
@@ -238,7 +238,7 @@ class ShallGenerateValidSchemataForConstexpr : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataForCallInReturn : SchemataFixutre {
+class ShallGenerateValidSchemaForCallInReturn : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_return.cpp").toString;
     }
@@ -256,7 +256,7 @@ class ShallGenerateValidSchemataForCallInReturn : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataClasses : SchemataFixutre {
+class ShallGenerateValidSchemaClasses : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_classes.cpp").toString;
     }
@@ -274,7 +274,7 @@ class ShallGenerateValidSchemataClasses : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataArraySub : SchemataFixutre {
+class ShallGenerateValidSchemaArraySub : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_array_subscript.cpp").toString;
     }
@@ -293,7 +293,7 @@ class ShallGenerateValidSchemataArraySub : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataWithLambda : SchemataFixutre {
+class ShallGenerateValidSchemaWithLambda : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_lambda.cpp").toString;
     }
@@ -311,7 +311,7 @@ class ShallGenerateValidSchemataWithLambda : SchemataFixutre {
     }
 }
 
-class ShallGenerateValidSchemataWithStructBind : SchemataFixutre {
+class ShallGenerateValidSchemaWithStructBind : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_struct_bind.cpp").toString;
     }
@@ -379,6 +379,26 @@ class ShallGenerateValidSchemaForBinOp : SchemataFixutre {
 class ShallGenerateValidSchemaForTemplate : SchemataFixutre {
     override string programFile() {
         return (testData ~ "schemata_template.cpp").toString;
+    }
+
+    override void test() {
+        mixin(EnvSetup(globalTestdir));
+        precondition(testEnv);
+
+        makeDextoolAnalyze(testEnv).addInputArg(programCode).addPostArg([
+                "--mutant", "all"
+                ]).run;
+
+        auto r = runDextoolTest(testEnv).addPostArg(["--mutant", "all"]).run;
+
+        testAnyOrder!SubStr(["Skipping schema because it failed to compile"]).shouldNotBeIn(
+                r.output);
+    }
+}
+
+class ShallGenerateValidSchemaForTerneryOp : SchemataFixutre {
+    override string programFile() {
+        return (testData ~ "schemata_ternery.cpp").toString;
     }
 
     override void test() {

--- a/plugin/mutate/testdata/schemata_ternery.cpp
+++ b/plugin/mutate/testdata/schemata_ternery.cpp
@@ -1,0 +1,10 @@
+/// @copyright Boost License 1.0, http://boost.org/LICENSE_1_0.txt
+/// @date 2021
+/// @author Joakim Brännström (joakim.brannstrom@gmx.com)
+
+int main(int argc, char** argv) {
+    char* x = argc > 2 ? *argv : argc > 42 ? argv[2] : 0;
+    char* y = argc > 2 ? *argv - 42 : argc > 42 ? 42 + argv[2] + 3 : 0;
+
+    return 0;
+}


### PR DESCRIPTION
The new version off schematan should work because the original
expression is kept except for one condition being replaced.