### PR TITLE
mutate: use a cache for blacklist

### DIFF
--- a/libs/dextool_clang_extensions/cpp_source/macro.cpp
+++ b/libs/dextool_clang_extensions/cpp_source/macro.cpp
@@ -53,4 +53,18 @@ bool dex_isMacroBodyExpansion(const CXSourceLocation location) {
     return SM.isMacroBodyExpansion(Loc);
 }
 
+bool dex_isAnyMacro(const CXSourceLocation location) {
+    // from CXSourceLocation.cpp
+    // function
+    // clang_Location_isInSystemHeader(CXSourceLocation location)
+
+    const clang::SourceLocation Loc = clang::SourceLocation::getFromRawEncoding(location.int_data);
+    if (Loc.isInvalid())
+        return false;
+
+    const clang::SourceManager& SM =
+        *static_cast<const clang::SourceManager*>(location.ptr_data[0]);
+    return SM.isInSystemMacro(Loc) || SM.isMacroBodyExpansion(Loc) || SM.isMacroArgExpansion(Loc);
+}
+
 } // namespace dextool_clang_extension

--- a/libs/dextool_clang_extensions/source/dextool/clang_extensions/package.d
+++ b/libs/dextool_clang_extensions/source/dextool/clang_extensions/package.d
@@ -243,6 +243,9 @@ extern (C++,dextool_clang_extension) {
      * expansion but not the expansion of an argument to a function-like macro.
      */
     extern (C++) bool dex_isMacroBodyExpansion(const CXSourceLocation location);
+
+    /// If the location is in any type of macro.
+    extern (C++) bool dex_isAnyMacro(const CXSourceLocation location);
 }
 
 Operator getExprOperator(const CXCursor expr) @trusted {


### PR DESCRIPTION
The clang queries are slow, about 3x slower than the previous
implementation.