### PR TITLE
mutate: new test cases should only be untagged when all alive/unknown

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -1095,7 +1095,7 @@ nothrow:
     void opCall(UpdateTestCaseTag data) {
         if (spinSql!(() => db.worklistApi.getCount([
                     Mutation.Status.alive, Mutation.Status.unknown
-                ])) != 0) {
+                ])) == 0) {
             spinSql!(() => db.testCaseApi.removeNewTestCaseTag);
             logger.info("All alive in worklist tested. Removing 'new test' tag.").collectException;
         }


### PR DESCRIPTION
tested.