### PR TITLE
mutate: improve speed for diff test

### DIFF
--- a/news.md
+++ b/news.md
@@ -6,6 +6,11 @@ New features for dextool mutate
    turned out to be a problem because some test suites contain executable test
    data. Thus the new configuration option `test_cmd_dir_search` is added to
    allow the search to be configured to be shallow (non-recursive).
+ * Improved speed when using diff mode by skipping the coverage
+   instrumentation. The user has already specified exactly what to test thus it
+   shouldn't be necessary to run it through the potentially slow coverage run. It
+   is assumed that a diff is usually pretty "small" and the change have entry
+   point coverage thus coverage data wouldn't help.
 
 # v4.2.0 Cat Gold 
 

--- a/plugin/mutate/doc/design/figures/test_mutant_fsm.pu
+++ b/plugin/mutate/doc/design/figures/test_mutant_fsm.pu
@@ -51,7 +51,7 @@ CheckMutantsLeft --> Done : allTested
 ChecksumTestCmds --> MeasureTestSuite
 
 MeasureTestSuite --> Error : unreliable
-MeasureTestSuite --> Coverage : useCov
+MeasureTestSuite --> Coverage : useCov && !hasConstraint
 MeasureTestSuite --> LoadSchematas : !useCov
 
 Coverage --> PropagateCov : !error

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -572,7 +572,7 @@ struct TestDriver {
         }, (PullRequest a) => fsm(CheckMutantsLeft.init), (MeasureTestSuite a) {
             if (a.unreliableTestSuite)
                 return fsm(Error.init);
-            if (self.covConf.use)
+            if (self.covConf.use && self.local.get!PullRequest.constraint.empty)
                 return fsm(Coverage.init);
             return fsm(LoadSchematas.init);
         }, (Coverage a) {


### PR DESCRIPTION
Skip coverage because the user has specified exactly what to test thus
coverage is unnecessary.