### PR TITLE
Create dextool.def

### DIFF
--- a/doc/install/dextool.def
+++ b/doc/install/dextool.def
@@ -40,14 +40,20 @@ From: ubuntu:18.04
     source ~/dlang/dmd-2.097.2/activate
     source ~/dlang/ldc-1.28.0/activate
     source ~/dlang/dub-1.22.0/activate
-#Installing Dextool
-%runscript
+    #Installing Dextool
     echo "Installing dextool $NOW"
     echo "Activating the D Compiler"
     source ~/dlang/dmd-2.097.2/activate
     echo "Done!"
-    git clone https://github.com/joakim-brannstrom/dextool.git
+    git clone https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch
     mkdir dextool/build
     cd dextool/build
-    cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ..
+    cmake -DCMAKE_INSTALL_PREFIX=/usr ..
     make install
+%environment
+    echo "Starting the dextool singularity environment..."
+    echo "Checking the version of dextool"
+    dextool --version
+    dextool --plugin-list
+    echo "Cloning the project to be used in the lab"
+    git clone  https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch

--- a/doc/install/dextool.def
+++ b/doc/install/dextool.def
@@ -34,15 +34,15 @@ From: ubuntu:18.04
     wget https://dlang.org/install.sh -O /usr/local/dlang/install.sh
     chmod +777 /usr/local/dlang/install.sh
     /usr/local/dlang/install.sh install -p /usr/local/bin dub
-    /usr/local/dlang/install.sh install -p /usr/local/bin ldc-1.28.0
+    /usr/local/dlang/install.sh install -p /usr/local/bin ldc-1.29.0
     echo "Copy ldc binary to bin"
-    chmod +777 /usr/local/bin/ldc-1.28.0
+    chmod +777 /usr/local/bin/ldc-1.29.0
     echo "Adding to path variables"
-    source /usr/local/bin/ldc-1.28.0/activate
+    source /usr/local/bin/ldc-1.29.0/activate
     #Installing Dextool
     echo "Installing dextool $NOW"
     echo "Activating the D Compiler"
-    git clone https://github.com/joakim-brannstrom/dextool.git
+    git clone https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch
     mkdir dextool/build
     cd dextool/build
     cmake -DCMAKE_INSTALL_PREFIX=/usr -DLOW_MEM=ON ..

--- a/doc/install/dextool.def
+++ b/doc/install/dextool.def
@@ -30,22 +30,19 @@ From: ubuntu:18.04
     apt-get -y install libsqlite3-dev
     echo "LLVM Dependencies + SQL Installed."
     echo "Installing D-Compiler and other auxilary resources"
-    mkdir -p ~/dlang
-    wget https://dlang.org/install.sh -O ~/dlang/install.sh
-    chmod +777 ~/dlang/install.sh
-    ~/dlang/install.sh install dmd-2.097.2
-    ~/dlang/install.sh install ldc-1.28.0
-    ~/dlang/install.sh install dub
+    mkdir -p /usr/local/dlang
+    wget https://dlang.org/install.sh -O /usr/local/dlang/install.sh
+    chmod +777 /usr/local/dlang/install.sh
+    /usr/local/dlang/install.sh install -p /usr/local/bin dub
+    /usr/local/dlang/install.sh install -p /usr/local/bin ldc-1.28.0
+    echo "Copy ldc binary to bin"
+    chmod +777 /usr/local/bin/ldc-1.28.0
     echo "Adding to path variables"
-    source ~/dlang/dmd-2.097.2/activate
-    source ~/dlang/ldc-1.28.0/activate
-    source ~/dlang/dub-1.22.0/activate
+    source /usr/local/bin/ldc-1.28.0/activate
     #Installing Dextool
     echo "Installing dextool $NOW"
     echo "Activating the D Compiler"
-    source ~/dlang/dmd-2.097.2/activate
-    echo "Done!"
-    git clone https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch
+    git clone https://github.com/joakim-brannstrom/dextool.git
     mkdir dextool/build
     cd dextool/build
     cmake -DCMAKE_INSTALL_PREFIX=/usr ..
@@ -55,5 +52,5 @@ From: ubuntu:18.04
     echo "Checking the version of dextool"
     dextool --version
     dextool --plugin-list
-    echo "Cloning the project to be used in the lab"
+    echo "Cloning the dextool project version 4.3.0"
     git clone  https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch

--- a/doc/install/dextool.def
+++ b/doc/install/dextool.def
@@ -45,7 +45,7 @@ From: ubuntu:18.04
     git clone https://github.com/joakim-brannstrom/dextool.git
     mkdir dextool/build
     cd dextool/build
-    cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+    cmake -DCMAKE_INSTALL_PREFIX=/usr -DLOW_MEM=ON ..
     make install
 %environment
     echo "Starting the dextool singularity environment..."
@@ -53,4 +53,3 @@ From: ubuntu:18.04
     dextool --version
     dextool --plugin-list
     echo "Cloning the dextool project version 4.3.0"
-    git clone  https://github.com/joakim-brannstrom/dextool.git --branch v4.3.0 --single-branch

--- a/doc/install/dextool.def
+++ b/doc/install/dextool.def
@@ -1,0 +1,53 @@
+Bootstrap: docker
+From: ubuntu:18.04
+# This file provides a Singularty image of the packages necessary to run dextool
+# Author: John Tinnerholm 2022-06-14 (Assumes the stable LLVM, which at this time is 13.)
+# For use in the LiU Course TDDD04
+%post -c /bin/bash
+    apt-get -y update
+    apt-get -y install wget
+    apt-get -y install curl
+    apt-get -y install git
+    apt-get -y install software-properties-common
+    apt-get -y update
+    echo "Installing LLVM repositories"
+    echo "Adding LLVM keys..."
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
+    echo "Keys added!"
+    add-apt-repository ppa:ubuntu-toolchain-r/test
+    add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main'
+    echo "Added llvm repository"
+    apt search llvm-
+    apt search clang-
+    apt search libclang-
+    apt-get -y install llvm-13-dev
+    apt-get -y install build-essential
+    apt-get -y install cmake
+    apt-get -y install llvm-13
+    apt-get -y install llvm-13-dev
+    apt-get -y install clang-13
+    apt-get -y install libclang-13-dev
+    apt-get -y install libsqlite3-dev
+    echo "LLVM Dependencies + SQL Installed."
+    echo "Installing D-Compiler and other auxilary resources"
+    mkdir -p ~/dlang
+    wget https://dlang.org/install.sh -O ~/dlang/install.sh
+    chmod +777 ~/dlang/install.sh
+    ~/dlang/install.sh install dmd-2.097.2
+    ~/dlang/install.sh install ldc-1.28.0
+    ~/dlang/install.sh install dub
+    echo "Adding to path variables"
+    source ~/dlang/dmd-2.097.2/activate
+    source ~/dlang/ldc-1.28.0/activate
+    source ~/dlang/dub-1.22.0/activate
+#Installing Dextool
+%runscript
+    echo "Installing dextool $NOW"
+    echo "Activating the D Compiler"
+    source ~/dlang/dmd-2.097.2/activate
+    echo "Done!"
+    git clone https://github.com/joakim-brannstrom/dextool.git
+    mkdir dextool/build
+    cd dextool/build
+    cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ..
+    make install


### PR DESCRIPTION
A singularity workflow for the latest version of dextool.

I suppose this can be used as an alternative to the install instructions presented here for users to run. 

Comments are very much welcome if this even is the right folder see https://sylabs.io/guides/3.5/user-guide/introduction.html

The idea is that we move the lab to containers this year, I got this working just now but there might be things that can be improved

The file can be tested by:
`singularity build dextool.def dextool.sif`

Followed by:
`singularity shell dextool.sif`
