### PR TITLE
Trend

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
@@ -653,8 +653,8 @@ struct MutationScoreHistoryTable {
 
     double score;
 
-    @ColumnName("file_id")
-    long fileId;
+    @ColumnName("filePath")
+    string filePath;
 }
 
 /** All functions that has been discovered in the source code.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
@@ -652,6 +652,9 @@ struct MutationScoreHistoryTable {
     SysTime timeStamp;
 
     double score;
+
+    @ColumnName("file_id")
+    long fileId;
 }
 
 /** All functions that has been discovered in the source code.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -274,7 +274,7 @@ struct Database {
 
         auto app = appender!(MutationScore[])();
         foreach (r; db.run(select!MutationScoreHistoryTable)) {
-            app.put(MutationScore(r.timeStamp, typeof(MutationScore.score)(r.score)));
+            app.put(MutationScore(r.timeStamp, typeof(MutationScore.score)(r.score), r.fileId));
         }
 
         return app.data.sort!((a, b) => a.timeStamp < b.timeStamp).array;
@@ -283,7 +283,7 @@ struct Database {
     /// Add a mutation score to the history table.
     void putMutationScore(const MutationScore score) @trusted {
         db.run(insert!MutationScoreHistoryTable, MutationScoreHistoryTable(0,
-                score.timeStamp, score.score.get));
+                score.timeStamp, score.score.get, score.fileId));
     }
 
     /// Trim the mutation score history table to only contain the last `keep` scores.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
@@ -320,7 +320,7 @@ struct TestCmdRuntime {
 struct MutationScore {
     SysTime timeStamp;
     NamedType!(double, Tag!"MutationScore", 0.0, TagStringable) score;
-    long fileId;
+    string filePath;
 }
 
 alias TestFilePath = NamedType!(Path, Tag!"TestFilePath", Path.init, Hashable, TagStringable);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/type.d
@@ -320,6 +320,7 @@ struct TestCmdRuntime {
 struct MutationScore {
     SysTime timeStamp;
     NamedType!(double, Tag!"MutationScore", 0.0, TagStringable) score;
+    long fileId;
 }
 
 alias TestFilePath = NamedType!(Path, Tag!"TestFilePath", Path.init, Hashable, TagStringable);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
@@ -285,7 +285,7 @@ struct TestCaseDeadStat {
         return buf.data;
     }
 
-    void toString(Writer)(ref Writer w) @safe const 
+    void toString(Writer)(ref Writer w) @safe const
             if (isOutputRange!(Writer, char)) {
         import std.ascii : newline;
         import std.format : formattedWrite;
@@ -1314,7 +1314,7 @@ private MutationScoreHistory reportMutationScoreHistory(
             acc += a.score.get;
             nr++;
         } else {
-            pretty.put(MutationScore(SysTime(last), typeof(MutationScore.score)(acc / nr)));
+            pretty.put(MutationScore(SysTime(last), typeof(MutationScore.score)(acc / nr), data[0].fileId));
             last = curr;
             acc = a.score.get;
             nr = 1;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
@@ -328,7 +328,7 @@ TestCaseDeadStat reportDeadTestCases(ref Database db) @safe {
 /// Only the mutation score thus a subset of all statistics.
 struct MutationScore {
     import core.time : Duration;
-    
+
     long alive;
     long killed;
     long timeout;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/analyzers.d
@@ -21,7 +21,6 @@ import std.exception : collectException;
 import std.format : format;
 import std.range : take, retro, only;
 import std.typecons : Flag, Yes, No, Tuple, Nullable, tuple;
-import std.container : DList;
 
 import my.named_type;
 import my.optional;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
@@ -38,18 +38,15 @@ void makeStats(ref Database db, string tag, Element root,
 private:
 
 // TODO: this function contains duplicated logic from the one in ../utility.d
-void overallStat(DList!MutationStat statList, Element base) {
+void overallStat(MutationStat[] statList, Element base) {
     import std.conv : to;
     import std.typecons : tuple;
     import core.time : Duration;
 
     MutationStat s;
-    MutationStat statVal;
     Duration predictedDone;
 
-    while(!statList.empty){
-      statVal = statList.front();
-
+    foreach(statVal; statList){
       s.untested += statVal.untested;
       s.killedByCompiler += statVal.killedByCompiler;
       s.worklist += statVal.worklist;
@@ -68,8 +65,6 @@ void overallStat(DList!MutationStat statList, Element base) {
       s.scoreData.totalTime.test += statVal.scoreData.totalTime.test;
       s.scoreData.aliveNoMut += statVal.scoreData.aliveNoMut;
       predictedDone += statVal.predictedDone;
-
-      statList.removeFront();
     }
 
     base.addChild("p").appendHtml(format("Mutation Score <b>%.3s</b>", s.score()));

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
@@ -12,6 +12,7 @@ module dextool.plugin.mutate.backend.report.html.page_stats;
 import logger = std.experimental.logger;
 import std.datetime : Clock, dur;
 import std.format : format;
+import std.container : DList;
 
 import arsd.dom : Element, Link;
 import my.path : AbsolutePath;
@@ -27,9 +28,14 @@ import dextool.plugin.mutate.backend.type : Mutation;
 void makeStats(ref Database db, string tag, Element root,
         const(Mutation.Kind)[] kinds, const AbsolutePath workListFname) @trusted {
     import dextool.plugin.mutate.backend.report.html.page_worklist;
-
     DashboardCss.h2(root.addChild(new Link(tag, null)).setAttribute("id", tag[1 .. $]), "Overview");
-    overallStat(reportStatistics(db, kinds), root.addChild("div"));
+    string[] files = db.getFilesStrings;
+    try{
+      logger.warningf("Paths %s", files);
+    } catch (Exception e){
+
+    }
+    overallStat(reportStatistics(db, kinds, files), root.addChild("div"));
     makeWorklistPage(db, root, workListFname);
     syncStatus(reportSyncStatus(db, kinds, 100), root);
 }
@@ -37,10 +43,11 @@ void makeStats(ref Database db, string tag, Element root,
 private:
 
 // TODO: this function contains duplicated logic from the one in ../utility.d
-void overallStat(const MutationStat s, Element base) {
+void overallStat(const DList!MutationStat sList, Element base) {
     import std.conv : to;
     import std.typecons : tuple;
-
+    //TODO, should loop
+    auto s = sList.front();
     base.addChild("p").appendHtml(format("Mutation Score <b>%.3s</b>", s.score));
     base.addChild("p", format("Time spent: %s", s.totalTime));
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
@@ -45,7 +45,6 @@ void overallStat(DList!MutationStat statList, Element base) {
 
     MutationStat s;
     MutationStat statVal;
-    double totalScore = 0;
     Duration predictedDone;
 
     while(!statList.empty){
@@ -66,16 +65,14 @@ void overallStat(DList!MutationStat statList, Element base) {
       s.scoreData.skipped += statVal.scoreData.skipped;
       s.scoreData.memOverload += statVal.scoreData.memOverload;
       s.scoreData.totalTime.compile += statVal.scoreData.totalTime.compile;
-      s.scoreData.totalTime.test += statVal.scoreData.totalTime.compile;
+      s.scoreData.totalTime.test += statVal.scoreData.totalTime.test;
       s.scoreData.aliveNoMut += statVal.scoreData.aliveNoMut;
       predictedDone += statVal.predictedDone;
-
-      totalScore += statVal.score();
 
       statList.removeFront();
     }
 
-    base.addChild("p").appendHtml(format("Mutation Score <b>%.3s</b>", totalScore));
+    base.addChild("p").appendHtml(format("Mutation Score <b>%.3s</b>", s.score()));
     base.addChild("p", format("Time spent: %s", s.totalTime));
 
     if (s.untested > 0 && s.predictedDone > 0.dur!"msecs") {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/page_stats.d
@@ -111,13 +111,13 @@ void syncStatus(SyncStatus status, Element root) {
     auto ts = TimeScalePointGraph("SyncStatus");
 
     ts.put("Test", TimeScalePointGraph.Point(status.test, 1.6));
-    ts.setColor("Test", "lightBlue");
+    ts.setColor("Test", "lightBlue", "lightBlue");
 
     ts.put("Code", TimeScalePointGraph.Point(status.code, 1.4));
-    ts.setColor("Code", "lightGreen");
+    ts.setColor("Code", "lightGreen", "lightGreen");
 
     ts.put("Coverage", TimeScalePointGraph.Point(status.coverage, 1.2));
-    ts.setColor("Coverage", "purple");
+    ts.setColor("Coverage", "purple", "purple");
 
     if (status.mutants.length != 0) {
         double y = 0.8;
@@ -125,7 +125,7 @@ void syncStatus(SyncStatus status, Element root) {
             ts.put("Mutant", TimeScalePointGraph.Point(v.updated, y));
             y += 0.3 / status.mutants.length;
         }
-        ts.setColor("Mutant", "red");
+        ts.setColor("Mutant", "red", "red");
     }
     ts.html(root, TimeScalePointGraph.Width(50));
 

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/tmpl.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/tmpl.d
@@ -194,6 +194,7 @@ struct TimeScalePointGraph {
     static struct Sample {
         Point[] values;
         string bgColor;
+        string brColor;
     }
 
     /// Name of the chart
@@ -206,9 +207,10 @@ struct TimeScalePointGraph {
         this.name = name;
     }
 
-    void setColor(string sample, string c) {
-        samples.update(sample, { return Sample(null, c); }, (ref Sample s) {
-            s.bgColor = c;
+    void setColor(string sample, string bgC, string brC) {
+        samples.update(sample, { return Sample(null, bgC, brC); }, (ref Sample s) {
+            s.bgColor = bgC;
+            s.brColor = brC;
         });
     }
 
@@ -232,7 +234,7 @@ struct TimeScalePointGraph {
                     JSONValue d;
                     d["label"] = sample.key;
                     d["backgroundColor"] = sample.value.bgColor;
-                    d["borderColor"] = sample.value.bgColor;
+                    d["borderColor"] = sample.value.brColor;
                     d["fill"] = false;
                     auto data = appender!(JSONValue[])();
                     foreach (v; sample.value.values) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
@@ -23,53 +23,73 @@ import dextool.plugin.mutate.backend.report.analyzers : reportTrendByCodeChange,
 import dextool.plugin.mutate.backend.report.html.constants;
 import dextool.plugin.mutate.backend.type : Mutation;
 
+string randomColorHex(){
+    auto rng = Random(unpredictableSeed);
+    int colorValue;
+    string color = "#";
+    for(int i = 0; i < 6; i++){
+      colorValue = uniform(0, 15, rng);
+      if(colorValue < 10){
+        color ~= to!string(colorValue);
+      }else{
+        switch(colorValue){
+          case 10: color ~= "a";
+            break;
+          case 11: color ~= "b";
+            break;
+          case 12: color ~= "c";
+            break;
+          case 13: color ~= "d";
+            break;
+          case 14: color ~= "e";
+            break;
+          case 15: color ~= "f";
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    return color;
+}
+
 void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[] kinds) @trusted {
     import std.datetime : SysTime;
     import dextool.plugin.mutate.backend.report.html.tmpl : TimeScalePointGraph;
 
     DashboardCss.h2(root.addChild(new Link(tag, null)).setAttribute("id", tag[1 .. $]), "Trend");
 
+    string[string] lineColor;
+    double[SysTime] totalScoreAtTime;
+    int[SysTime] fileCountAtTime;
     auto base = root.addChild("div");
-
     auto ts = TimeScalePointGraph("ScoreHistory");
 
     const history = reportMutationScoreHistory(db);
-    string color;
-    int colorValue;
-    auto rng = new Random(unpredictableSeed);
     double score;
+    string color;
 
+    //Add all the score histories to the graph
     if (history.data.length > 1){
       foreach(value; history.data){
-        color = "#";
-        for(int i = 0; i < 6; i++){
-          colorValue = uniform(0, 15, rng);
-          if(colorValue < 10){
-            color ~= to!string(colorValue);
-          }else{
-            switch(colorValue){
-              case 10: color ~= "a";
-                break;
-              case 11: color ~= "b";
-                break;
-              case 12: color ~= "c";
-                break;
-              case 13: color ~= "d";
-                break;
-              case 14: color ~= "e";
-                break;
-              case 15: color ~= "f";
-                break;
-              default:
-                break;
-            }
-          }
-        }
+        color = randomColorHex();
         score = rint(value.score.get * 1000)/1000;
-
+        totalScoreAtTime[value.timeStamp] += score;
+        fileCountAtTime[value.timeStamp] += 1;
+        lineColor[value.filePath] = color;
         ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, score));
         ts.setColor(value.filePath, color, color);
       }
+    }
+
+    //Generate Average
+    foreach(scoreAtTime; totalScoreAtTime.byKeyValue){
+      auto time = scoreAtTime.key;
+      score = scoreAtTime.value / fileCountAtTime[time];
+      score = rint(score * 1000)/1000;
+      ts.put("Average", TimeScalePointGraph.Point(time, score));
+      color = randomColorHex();
+      ts.setColor("Average", color, color);
     }
 
     ts.html(base, TimeScalePointGraph.Width(80));

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
@@ -11,6 +11,8 @@ module dextool.plugin.mutate.backend.report.html.trend;
 
 import logger = std.experimental.logger;
 import std.format : format;
+import std.random;
+import std.conv;
 
 import arsd.dom : Element, Link;
 
@@ -31,17 +33,24 @@ void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[]
     auto ts = TimeScalePointGraph("ScoreHistory");
 
     const history = reportMutationScoreHistory(db);
+    string color;
+    auto rng = new Random(unpredictableSeed);
 
-
+    //TODO: Color generation should be imporved, is not hexadecimal currently
     if (history.data.length > 1){
       foreach(value; history.data){
+        color = "#";
+        for(int i = 0; i < 6; i++){
+          color ~= to!string(uniform(0, 9, rng));
+        }
         ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, value.score.get));
+        ts.setColor(value.filePath, color, color);
       }
     }
 
     ts.html(base, TimeScalePointGraph.Width(80));
         base.addChild("p")
             .appendHtml(
-                    "<i>trend</i> is a prediction of how the mutation score will change based on previous scores.");
+                    "<i>trend</i> is a graph displaying how the MutationScore has changed between tests.");
 
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
@@ -34,14 +34,34 @@ void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[]
 
     const history = reportMutationScoreHistory(db);
     string color;
+    int colorValue;
     auto rng = new Random(unpredictableSeed);
 
-    //TODO: Color generation should be imporved, is not hexadecimal currently
     if (history.data.length > 1){
       foreach(value; history.data){
         color = "#";
         for(int i = 0; i < 6; i++){
-          color ~= to!string(uniform(0, 9, rng));
+          colorValue = uniform(0, 15, rng);
+          if(colorValue < 10){
+            color ~= to!string(colorValue);
+          }else{
+            switch(colorValue){
+              case 10: color ~= "a";
+                break;
+              case 11: color ~= "b";
+                break;
+              case 12: color ~= "c";
+                break;
+              case 13: color ~= "d";
+                break;
+              case 14: color ~= "e";
+                break;
+              case 15: color ~= "f";
+                break;
+              default:
+                break;
+            }
+          }
         }
         ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, value.score.get));
         ts.setColor(value.filePath, color, color);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
@@ -13,6 +13,7 @@ import logger = std.experimental.logger;
 import std.format : format;
 import std.random;
 import std.conv;
+import std.math;
 
 import arsd.dom : Element, Link;
 
@@ -36,6 +37,7 @@ void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[]
     string color;
     int colorValue;
     auto rng = new Random(unpredictableSeed);
+    double score;
 
     if (history.data.length > 1){
       foreach(value; history.data){
@@ -63,7 +65,9 @@ void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[]
             }
           }
         }
-        ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, value.score.get));
+        score = rint(value.score.get * 1000)/1000;
+
+        ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, score));
         ts.setColor(value.filePath, color, color);
       }
     }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/trend.d
@@ -28,9 +28,20 @@ void makeTrend(ref Database db, string tag, Element root, const(Mutation.Kind)[]
 
     auto base = root.addChild("div");
 
+    auto ts = TimeScalePointGraph("ScoreHistory");
+
     const history = reportMutationScoreHistory(db);
 
-    foreach(data; history.data){
-      base.addChild("p", format("%s (%s): %s", data.filePath, data.timeStamp, data.score.get));
+
+    if (history.data.length > 1){
+      foreach(value; history.data){
+        ts.put(value.filePath, TimeScalePointGraph.Point(value.timeStamp, value.score.get));
+      }
     }
+
+    ts.html(base, TimeScalePointGraph.Width(80));
+        base.addChild("p")
+            .appendHtml(
+                    "<i>trend</i> is a prediction of how the mutation score will change based on previous scores.");
+
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/json.d
@@ -161,7 +161,7 @@ final class ReportJson {
         if (ReportSection.summary in sections) {
             const statList = reportStatistics(db, kinds, db.getFilesStrings);
             //TODO, should loop
-            auto stat = statList.front();
+            auto stat = statList[0];
             JSONValue s = ["alive" : stat.alive];
             s.object["no_coverage"] = stat.noCoverage;
             s.object["alive_nomut"] = stat.aliveNoMut;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/json.d
@@ -159,7 +159,9 @@ final class ReportJson {
             reportTrendByCodeChange;
 
         if (ReportSection.summary in sections) {
-            const stat = reportStatistics(db, kinds);
+            const statList = reportStatistics(db, kinds, db.getFilesStrings);
+            //TODO, should loop
+            auto stat = statList.front();
             JSONValue s = ["alive" : stat.alive];
             s.object["no_coverage"] = stat.noCoverage;
             s.object["alive_nomut"] = stat.aliveNoMut;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
@@ -249,7 +249,7 @@ void report(ref Database db, const MutationKind[] userKinds, const ConfigReport 
             logger.info("Summary");
             auto summaryList = reportStatistics(db, kinds, db.getFilesStrings);
             //TODO, should loop
-            auto summary = summaryList.front();
+            auto summary = summaryList[0];
             writeln(summary.toString);
 
             syncStatus(db, kinds);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/plain.d
@@ -247,7 +247,9 @@ void report(ref Database db, const MutationKind[] userKinds, const ConfigReport 
 
         if (ReportSection.summary in sections) {
             logger.info("Summary");
-            auto summary = reportStatistics(db, kinds);
+            auto summaryList = reportStatistics(db, kinds, db.getFilesStrings);
+            //TODO, should loop
+            auto summary = summaryList.front();
             writeln(summary.toString);
 
             syncStatus(db, kinds);

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -1113,8 +1113,8 @@ nothrow:
         if (spinSql!(() => db.timeoutApi.countMutantTimeoutWorklist) != 0)
             return;
 
-        //TODO: Should get these from the database
-        string[] files = ["src/mob.cpp", "src/util.h", "src/entity.h", "src/window.cpp", "src/window.h", "src/mob.h", "src/game.cpp"];
+        //TODO: Should get these from the database+
+        string[] files = ["src/entity.h", "src/event.h", "src/game.cpp", "src/game.h", "src/main.cpp", "src/mob.cpp", "src/mob.h", "src/mobsystem.cpp", "src/mobsystem.h", "src/physics.h", "src/physicssystem.cpp", "src/physicssystem.h", "src/rendersystem.cpp", "src/rendersystem.h", "src/system.h", "src/util.h", "src/window.cpp", "src/window.h"];
         const scores = reportScores(*db, kinds, files);
         // 10000 mutation scores is only ~80kbyte. Should be enough entries
         // without taking up unreasonable amount of space.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -1116,12 +1116,13 @@ nothrow:
         //TODO: Should get these from the database+
         string[] files = ["src/entity.h", "src/event.h", "src/game.cpp", "src/game.h", "src/main.cpp", "src/mob.cpp", "src/mob.h", "src/mobsystem.cpp", "src/mobsystem.h", "src/physics.h", "src/physicssystem.cpp", "src/physicssystem.h", "src/rendersystem.cpp", "src/rendersystem.h", "src/system.h", "src/util.h", "src/window.cpp", "src/window.h"];
         const scores = reportScores(*db, kinds, files);
+        const time = Clock.currTime;
         // 10000 mutation scores is only ~80kbyte. Should be enough entries
         // without taking up unreasonable amount of space.
         foreach(score; scores){
             spinSql!(() @trusted {
                 auto t = db.transaction;
-                db.putMutationScore(MutationScore(Clock.currTime, typeof(MutationScore.score)(score.score), score.filePath));
+                db.putMutationScore(MutationScore(time, typeof(MutationScore.score)(score.score), score.filePath));
                 db.trimMutationScore(10000);
                 t.commit;
             });


### PR DESCRIPTION
Now displays the Trend graph as individual files, where the y axis is the mutation score and the x axis is the time when the tests were run. Also added an "Average" line for all the files. If you press the name of the file at the top it's line is removed from the graph. 

**Imporvements that should be fixed**:
**report/json.d:** Should loop over values (Not working as intended currently)
**report/plain.d:** Should loop over values (Not working as intended currently) 
**backend/test_mutant/package.d:** _string[] files = ["....]_ is hardcoded, should get the file paths from the database via **db.getFilesStrings()**, but I am having difficulties with "@safe nothrow"