### PR TITLE
mutate: doctime error fix

### DIFF
--- a/plugin/mutate/data/index.js
+++ b/plugin/mutate/data/index.js
@@ -110,6 +110,8 @@ function openTab(evt, open, tabGroup) {
 function setDocTime() {
     var div = document.getElementById("reportGenerationDate");
     var modDate = convertDate(new Date(document.lastModified));
+    if (div == null)
+        return;
     div.innerText += " " + modDate;
 }
 


### PR DESCRIPTION
mutate site crashes when trying to add document time (not needed on this page)