### PR TITLE
mutate: Add contributors.md

### DIFF
--- a/plugin/mutate/contributors.md
+++ b/plugin/mutate/contributors.md
@@ -1,0 +1,15 @@
+# Notable contributions
+
+The following people deserves recognition as a result of their help and inspiration in the development and implementation of dextool mutate.
+
+- [Sten Vercammen](https://github.com/Sten-Vercammen)
+- [John Tinnerholm](https://github.com/JKRT)
+- [John Törnblom](https://github.com/john-tornblom)
+- [Eric Lindskog](https://github.com/EricLindskog) & [Lisa Habbe](https://github.com/lisahabbe)
+- [Axel Boström](https://github.com/axelbostrom), [Oliver Green](https://github.com/OliverGreen27) & [Viktor Norgren](https://github.com/virrenn)
+
+
+There are, of course, a lot more people that have contributed directly (or indirectly) to the development of dextool mutate. 
+
+To all of you, **thank you**!
+


### PR DESCRIPTION
Obviously, one can check the "contributors" information under "Insights", but I feel like this is needed somewhere more public.

If I have forgotten someone, please tell me so that I can add them.