### PR TITLE
mutate: add upper limit of cached schema fragments

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/schemata.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/schemata.d
@@ -1480,8 +1480,21 @@ struct SchemaBuildState {
         builder.useProbability = true;
         builder.useProbablitySmallSize = false;
         builder.mutantsPerSchema = mutantsPerSchema.get;
-        builder.minMutantsPerSchema = mutantsPerSchema.get;
         builder.thresholdStartValue = 1.0;
+
+        // seems like 200 Mbyte is large enough to generate scheman with >1000
+        // mutants easily when running on LLVM.
+        enum MaxCache = 200 * 1024 * 1024;
+        if (builder.cacheSize > MaxCache) {
+            // panic mode, just empty it as fast as possible.
+            logger.infof(
+                    "Schema cache is %s bytes (limit %s). Producing as many schemas as possible to flush the cache.",
+                    builder.cacheSize, MaxCache);
+
+            builder.minMutantsPerSchema = minMutantsPerSchema.get;
+        } else {
+            builder.minMutantsPerSchema = mutantsPerSchema.get;
+        }
     }
 
     void setReducedIntermediate(long sizeDiv, long threshold) {


### PR DESCRIPTION
The purpose is to avoid running out of memory.