### PR TITLE
ctestdouble: failed type deduction should not crash

### DIFF
--- a/libs/cpptooling/source/cpptooling/analyzer/clang/analyze_helper.d
+++ b/libs/cpptooling/source/cpptooling/analyzer/clang/analyze_helper.d
@@ -237,7 +237,8 @@ do {
 
         logTypeResult(tr, indent);
         tr.get.primary.type.kind.info.match!(ignore!(TypeKind.FuncInfo), (_) {
-            assert(0, "wrong type");
+            logger.infof("Wrong type detected when trying to deduce the referenced concrete type of %s",
+                c.location());
         });
 
         return tr;


### PR DESCRIPTION
A warning is good enough.