### PR TITLE
mutate: modify timeout calculation mainly for schema

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/timeout.d
@@ -1,24 +1,11 @@
 /**
-Copyright: Copyright (c) 2019, Joakim Brännström. All rights reserved.
+Copyright: Copyright (c) Joakim Brännström. All rights reserved.
 License: MPL-2
 Author: Joakim Brännström (joakim.brannstrom@gmx.com)
 
 This Source Code Form is subject to the terms of the Mozilla Public License,
 v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
-
-# Analyze
-
-The worklist should not be cleared during an analyze phase.
-Any mutant that has been removed in the source code will be automatically
-removed from the worklist because the tables is setup with ON DELETE CASCADE.
-
-Thus by not removing it old timeout mutants that need more work will be
-"resumed".
-
-# Test
-
-TODO: describe the test phase and FSM
 */
 module dextool.plugin.mutate.backend.test_mutant.timeout;
 
@@ -95,10 +82,7 @@ std_.datetime.Duration calculateTimeout(const long iter,
     import core.time : dur;
     import std.math : sqrt;
 
-    static immutable double constant_factor = 1.5;
-    const double n = iter;
-
-    const double scale = constant_factor + sqrt(n) * timeoutScaleFactor;
+    const double scale = timeoutScaleFactor + sqrt(cast(double) iter) * 2.0;
     return (1L + (cast(long)(base.total!"msecs" * scale))).dur!"msecs";
 }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -186,8 +186,8 @@ struct ArgParser {
         app.put("check_schemata = true");
         app.put(null);
         app.put(
-                "# scale factor used when calculating the timeout for tests when they are executed with a schema injected.");
-        app.put(format!"# the default scale factor is %s but that may not be enough for scheman because"(
+                "# multiplier used when calculating the timeout for tests when they are executed with a schema injected.");
+        app.put(format!"# the default multiplier is %s but that may not be enough for scheman because"(
                 schema.timeoutScaleFactor));
         app.put("# the now modified source code with the schema, containing 1000ths of mutants, result in a significantly slower test");
         app.put(format!"# timeout_scale = %s"(schema.timeoutScaleFactor));


### PR DESCRIPTION
The user need to be able to control the initial multiplier instead of the scale factor.