### PR TITLE
libclang: Adding lib support for latest clang package method in archlinux

### DIFF
--- a/cmake/introspect_llvm.d
+++ b/cmake/introspect_llvm.d
@@ -141,9 +141,13 @@ string llvmLibClang() {
         "clangFrontendTool", "clangRewriteFrontend", "clangDynamicASTMatchers",
         "clangFrontend", "clangASTMatchers", "clangParse", "clangSerialization",
         "clangRewrite", "clangSema", "clangEdit", "clangAnalysis",
-        "clangAST", "clangLex", "clangBasic"
+        "clangAST", "clangLex", "clangBasic","clang-cpp"
     ]) {
-        rval ~= "-l" ~ findLibOrBackup(lib, lib);
+        string foundLib= findLibOrSkip(lib);
+        if( foundLib !is null){
+            rval ~= "-l" ~ foundLib;
+        }
+  
     }
 
     rval ~= findLib("libclang.so", PartialLibrary("clang")).visit!(
@@ -182,7 +186,7 @@ Library findLib(string lib, PartialLibrary backup) {
     return backup.Library;
 }
 
-string findLibOrBackup(string lib, string backup) {
+string findLibOrSkip(string lib) {
     // dfmt off
     foreach (p; llvmSearchPaths
              .filter!(a => exists(a))
@@ -195,7 +199,7 @@ string findLibOrBackup(string lib, string backup) {
     }
     // dfmt on
 
-    return backup;
+    return null;
 }
 
 /** The order the paths are listed affects the priority. The higher up the


### PR DESCRIPTION
### Summary

This PR addresses the issue described in #1738, where a library linking failure occurs during the install process due to unresolved libraries.

### Problem

Upon reviewing the introspect_llvm.d file, I identified that the current findLibOrBackup function is problematic. It returns the library name regardless of whether the library is actually found, which leads to linker errors when the library is not present, as detailed in #1738.
Solution

To resolve this, I propose the following changes:

   -  Replace findLibOrBackup with findLibOrSkip: This new function will only return the library if it is found, otherwise, it will skip it. This prevents incorrect library names from being passed to the linker.
   -  Add clang-cpp to the search list: In recent versions of Clang, several libraries have been bundled into clang-cpp. Including this in the search will ensure proper linking in modern Clang distributions.

These changes ensure that the installation process will correctly handle missing libraries and avoid linker errors.