### PR TITLE
mutate: fix collapsed HTML report navbar on narrow screens

### DIFF
--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
@@ -940,6 +940,15 @@ void addNavbarItems(NavbarItem[] items, Element root) @trusted {
     }
 }
 
+Element makeNarrowScreenNavbar(Element root) @trusted {
+    auto nav = root.addChild("ul");
+    nav.setAttribute("id", "navbar-narrow-screen");
+    nav.addClass("nav");
+    nav.addClass("navbar-nav");
+    nav.addClass("visible-xs-block");
+    return nav;
+}
+
 struct InitMsg {
 }
 
@@ -1491,6 +1500,7 @@ auto spawnOverviewActor(OverviewActor.Impl self, FlowControlActor.Address flowCt
         ctx.state.files.toIndex(content, HtmlStyle.fileDir);
 
         addNavbarItems(navbarItems, index.mainBody.getElementById("navbar-sidebar"));
+        addNavbarItems(navbarItems, makeNarrowScreenNavbar(index.mainBody.getElementById("navbar")));
 
         File(buildPath(ctx.state.logDir, "index" ~ HtmlStyle.ext), "w").write(index.toPrettyString);
     }


### PR DESCRIPTION
The HTML report showed Bootstrap's hamburger button when the viewport became narrow, but clicking it did nothing because the collapsed navbar was empty: 
<img width="759" height="540" alt="image" src="https://github.com/user-attachments/assets/513fe603-e754-4fec-b87b-29806a96aafc" />

Populate the collapsed navbar with the same links as the sidebar so navigation works in responsive layouts. Clicking now results in the following:
<img width="741" height="540" alt="image" src="https://github.com/user-attachments/assets/388c09a4-ee01-47fa-a88b-49e34f3be5cd" />
