### PR TITLE
mutate: import gcov --json-format coverage

### DIFF
--- a/plugin/mutate/README_config.md
+++ b/plugin/mutate/README_config.md
@@ -737,14 +737,22 @@ This option can greatly speed up the testing of all mutants.
 It is strongly recommended to also track the test files such that the coverage
 is automatically updated when the tests are changed (`generic.test_paths`).
 
-`runtime`: The option `inject` mean that dextool inject the runtime needed for
-mutation testing in all roots or those specified by `inject_runtime_impl`. This
-is a nice and automated process. If this doesn't work because you are running
-on an embedded system and need a modified schema runtime, linking errors etc
-then you can opt to use the `library` option. It means that you precompile the
-runtime and manually link with the library. Dextool will do no magic.
+`runtime`: Controls how dextool's built-in coverage runtime is added when
+dextool gathers coverage itself. The option `inject` mean that dextool inject
+the runtime needed for mutation testing in all roots or those specified by
+`inject_runtime_impl`. This is a nice and automated process. If this doesn't
+work because you are running on an embedded system and need a modified schema
+runtime, linking errors etc then you can opt to use the `library` option. It
+means that you precompile the runtime and manually link with the library.
+Dextool will do no magic.
 
 `inject_runtime_impl`: Inject the runtime in only these files.
+
+`gcov_json`: An optional advanced path to import coverage from GCC
+`gcov --json-format` output instead of using dextool's built-in source
+instrumentation. Use this when your build already produces gcov data. The
+value may be one or more `.gcov.json` or `.gcov.json.gz` files, or directories
+containing those artifacts.
 
 ## [database]
 

--- a/plugin/mutate/doc/design/gcov_json_import.md
+++ b/plugin/mutate/doc/design/gcov_json_import.md
@@ -37,14 +37,16 @@ If no gcov JSON input is configured:
 If gcov JSON input is configured:
 
 - mutate tries to import coverage from gcov `--json-format` output
+- coverage use is enabled for `mutate test`, even when `[coverage].use` is not
+  set explicitly
 - if import succeeds, built-in instrumentation is skipped
 - if import does not produce usable coverage, mutate warns and falls back to
   the built-in coverage flow when possible
 
 The supported user-facing input forms are:
 
-- `--gcov-json <path>` on the command line
-- `[coverage].gcov_json` in TOML
+- `--gcov-json <path>` on the command line, repeatable for multiple inputs
+- `[coverage].gcov_json` in TOML, as either a string or an array of strings
 - a single gcov JSON file
 - multiple gcov JSON files
 - a directory containing `.gcov.json` and/or `.gcov.json.gz` files
@@ -53,7 +55,7 @@ The supported user-facing input forms are:
 
 The feature fits into the existing coverage flow in `mutate test`.
 
-After the normal coverage initialization step:
+Before the built-in coverage runtime is injected or otherwise prepared:
 
 - if gcov JSON input is configured, the coverage FSM tries `ImportGcovJson`
 - if gcov import succeeds, coverage collection is done
@@ -88,8 +90,12 @@ When gcov JSON is imported:
 - the importer accepts GCC `gcov --json-format` output
 - relative paths, absolute paths, and `current_working_directory` are handled
   when resolving gcov source paths
+- relative source paths without `current_working_directory` are resolved from
+  the gcov JSON input file's directory
 - the importer resolves gcov file entries to analyzed source files
 - one imported line status is stored for each gcov line present in the input
+- repeated line counts from multiple gcov JSON inputs are summed before
+  coverage status is calculated
 - `count > 0` becomes covered
 - `count == 0` becomes non-covered
 - missing gcov lines remain unknown
@@ -113,6 +119,8 @@ This includes cases such as:
 
 - bad JSON
 - missing `files`
+- `files` that is not an array
+- malformed individual file entries
 - nonexistent inputs
 - empty directories
 - unsupported filenames
@@ -161,7 +169,8 @@ it.
 
 For a mutant range:
 
-- if any known imported line in the range is covered, the mutant is covered
+- if any known imported line in the range is covered, the mutant is not marked
+  `noCoverage` by propagation
 - if at least one known imported line exists in the range and none are
   covered, the mutant is `noCoverage`
 - if no imported line exists in the range, coverage remains unknown
@@ -177,9 +186,12 @@ Added or extended integration coverage includes:
 
 - built-in instrumentation is still used when `--gcov-json` is not configured
 - gcov import bypasses built-in instrumentation when configured
+- gcov JSON configuration enables coverage use from both CLI and TOML
 - CLI and TOML configuration both work
 - `.gcov.json`, `.gcov.json.gz`, and directory inputs work
 - relative paths, absolute paths, and `current_working_directory` work
+- numeric line/count fields may be JSON numbers or strings
+- duplicate line counts across inputs are merged
 - `count > 0`, `count == 0`, and missing lines map to covered, non-covered, and
   unknown
 - re-import replaces old imported coverage instead of accumulating stale data
@@ -208,10 +220,11 @@ objects, a clean sequential rebuild of the mutate binary has been enough:
 cmake --build build-test --target dextool_debug-mutate --clean-first -j1
 ```
 
-## Remaining Manual Checks
+## Optional Manual Checks
 
-The automated tests cover the core behavior. Optional extra manual checking can
-still be useful with a small gcov-producing C++ sample:
+The automated tests cover the core behavior with generated gcov JSON. Optional
+extra manual checking can still be useful with a real GCC/gcov-producing C++
+sample:
 
 - generate gcov JSON with both covered and uncovered lines inside the same
   analyzed function

--- a/plugin/mutate/doc/design/gcov_json_import.md
+++ b/plugin/mutate/doc/design/gcov_json_import.md
@@ -96,6 +96,8 @@ When gcov JSON is imported:
 - one imported line status is stored for each gcov line present in the input
 - repeated line counts from multiple gcov JSON inputs are summed before
   coverage status is calculated
+- negative line counts produce warnings and are treated as zero before merging,
+  so corrupted interrupted `.gcda` data cannot cancel valid positive coverage
 - `count > 0` becomes covered
 - `count == 0` becomes non-covered
 - missing gcov lines remain unknown
@@ -192,6 +194,7 @@ Added or extended integration coverage includes:
 - relative paths, absolute paths, and `current_working_directory` work
 - numeric line/count fields may be JSON numbers or strings
 - duplicate line counts across inputs are merged
+- negative line counts warn and are clamped before merging
 - `count > 0`, `count == 0`, and missing lines map to covered, non-covered, and
   unknown
 - re-import replaces old imported coverage instead of accumulating stale data

--- a/plugin/mutate/doc/design/gcov_json_import_precision.md
+++ b/plugin/mutate/doc/design/gcov_json_import_precision.md
@@ -1,0 +1,230 @@
+# gcov JSON Import
+
+This is a temporary development note for the gcov JSON import work. Its
+purpose is to capture the problem, the chosen implementation, and what was
+verified while the feature is being developed and reviewed.
+
+It may be removed later, merged into longer-lived design documentation, or
+rewritten once the feature and its final documentation have settled.
+
+## Summary
+
+This note records the full gcov JSON coverage import feature for
+`mutate test`.
+
+The goal of the feature is to let mutate use coverage that has already been
+produced by a GCC/gcov-based build instead of always gathering coverage through
+dextool's built-in source instrumentation.
+
+At a high level the feature adds:
+
+- an optional gcov JSON import path in `mutate test`
+- CLI and TOML configuration for that import path
+- translation from gcov line counts to dextool coverage data in SQLite
+- fallback to the built-in instrumentation flow when gcov import is not used or
+  cannot provide usable coverage
+- precise line-based behavior for HTML/source reporting and `noCoverage`
+  propagation when gcov import is used
+
+## User-Facing Behavior
+
+The gcov import path is optional.
+
+If no gcov JSON input is configured:
+
+- mutate behaves as before and gathers coverage with built-in instrumentation
+
+If gcov JSON input is configured:
+
+- mutate tries to import coverage from gcov `--json-format` output
+- if import succeeds, built-in instrumentation is skipped
+- if import does not produce usable coverage, mutate warns and falls back to
+  the built-in coverage flow when possible
+
+The supported user-facing input forms are:
+
+- `--gcov-json <path>` on the command line
+- `[coverage].gcov_json` in TOML
+- a single gcov JSON file
+- multiple gcov JSON files
+- a directory containing `.gcov.json` and/or `.gcov.json.gz` files
+
+## Overall Design
+
+The feature fits into the existing coverage flow in `mutate test`.
+
+After the normal coverage initialization step:
+
+- if gcov JSON input is configured, the coverage FSM tries `ImportGcovJson`
+- if gcov import succeeds, coverage collection is done
+- otherwise the FSM continues into the existing built-in instrumentation path
+
+This keeps gcov import as an additive feature rather than changing the default
+coverage behavior.
+
+## Database And Storage Model
+
+The feature uses two representations of coverage:
+
+1. region coverage in the existing coverage tables
+2. imported line coverage in a separate table when gcov import is used
+
+The existing region coverage tables are kept because they are already used by
+the built-in instrumentation flow and by older coverage consumers.
+
+A new table stores imported line coverage:
+
+- table: `src_cov_imported_line`
+- key shape: unique `(file_id, line)`
+- status: boolean
+
+This table is created for new databases and added for existing databases by a
+schema migration.
+
+## Import Behavior
+
+When gcov JSON is imported:
+
+- the importer accepts GCC `gcov --json-format` output
+- relative paths, absolute paths, and `current_working_directory` are handled
+  when resolving gcov source paths
+- the importer resolves gcov file entries to analyzed source files
+- one imported line status is stored for each gcov line present in the input
+- `count > 0` becomes covered
+- `count == 0` becomes non-covered
+- missing gcov lines remain unknown
+- region coverage is still derived from the imported line counts and written to
+  the existing region coverage tables
+
+Re-import clears old imported line coverage first, so the latest import wins.
+
+The built-in instrumentation save path also clears imported line coverage, so a
+later non-gcov run cannot accidentally reuse stale gcov line data.
+
+## Validation And Fallback
+
+The gcov import path is intentionally forgiving because it is optional and the
+built-in instrumentation flow still exists.
+
+When possible, malformed or unusable gcov input produces warnings and mutate
+falls back to built-in coverage instead of terminating the whole run.
+
+This includes cases such as:
+
+- bad JSON
+- missing `files`
+- nonexistent inputs
+- empty directories
+- unsupported filenames
+- no analyzed coverage regions
+- no matching analyzed source files
+
+## Precision Work
+
+The first version of gcov import stored imported coverage only in the existing
+region-based coverage tables. That was enough to guide mutation testing in
+coarse regions, but it lost line precision.
+
+In practice this meant that if a large analyzed region contained both covered
+and uncovered lines, the HTML report could show the whole region as covered and
+`noCoverage` propagation could treat uncovered lines as covered.
+
+The motivating case was a small C++ sample where gcov reported an uncovered
+line inside a function that otherwise had covered lines, but the HTML report
+still showed that uncovered line as covered because the whole function region
+had been reduced to a single covered status.
+
+The precision fix keeps compatibility with the built-in instrumentation flow
+while allowing gcov import consumers to prefer exact imported line data.
+
+## Consumers Updated To Prefer Imported Line Coverage
+
+### HTML Source Report
+
+The HTML file report now checks for imported line coverage first.
+
+If imported line coverage exists for a file:
+
+- line classes come directly from imported line coverage
+
+Otherwise:
+
+- the old region-to-line projection is used
+
+This keeps the built-in instrumentation path unchanged while making gcov import
+precise in source views.
+
+### No-Coverage Propagation
+
+`noCoverage` propagation now prefers imported line coverage for files that have
+it.
+
+For a mutant range:
+
+- if any known imported line in the range is covered, the mutant is covered
+- if at least one known imported line exists in the range and none are
+  covered, the mutant is `noCoverage`
+- if no imported line exists in the range, coverage remains unknown
+
+Files without imported line coverage still use the old region-based logic.
+
+## Verification Performed
+
+The implementation was verified with mutate integration tests over C++ sample
+inputs.
+
+Added or extended integration coverage includes:
+
+- built-in instrumentation is still used when `--gcov-json` is not configured
+- gcov import bypasses built-in instrumentation when configured
+- CLI and TOML configuration both work
+- `.gcov.json`, `.gcov.json.gz`, and directory inputs work
+- relative paths, absolute paths, and `current_working_directory` work
+- `count > 0`, `count == 0`, and missing lines map to covered, non-covered, and
+  unknown
+- re-import replaces old imported coverage instead of accumulating stale data
+- failure cases warn and fall back when possible
+- HTML reporting uses imported line precision
+- `noCoverage` propagation uses imported line precision
+
+## Commands Used For Verification
+
+Unit tests may be run in parallel:
+
+```sh
+cmake --build build-test --target mutate_unittest__run --parallel
+```
+
+Integration tests should be run sequentially to avoid excessive memory use:
+
+```sh
+cmake --build build-test --target dextool_debug-mutate_integration__run -j1
+```
+
+If the build tree has been interrupted and the linker reports stale or invalid
+objects, a clean sequential rebuild of the mutate binary has been enough:
+
+```sh
+cmake --build build-test --target dextool_debug-mutate --clean-first -j1
+```
+
+## Remaining Manual Checks
+
+The automated tests cover the core behavior. Optional extra manual checking can
+still be useful with a small gcov-producing C++ sample:
+
+- generate gcov JSON with both covered and uncovered lines inside the same
+  analyzed function
+- run analyze + mutate test with `--gcov-json`
+- generate the HTML report
+- confirm that covered and uncovered lines inside the same analyzed function are
+  shown with different coverage classes
+
+## Scope
+
+This note covers the full gcov JSON import feature in the branch, including the
+later precision work for reporting and `noCoverage`.
+
+The built-in instrumentation coverage path remains region-based and unchanged in
+behavior, except that it now clears any previously imported gcov line coverage
+before saving fresh built-in coverage results.

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/schema.d
@@ -115,6 +115,7 @@ immutable schemaMutantV2Table = "schemata_mutant_v2";
 immutable schemaSizeQTable = "schema_size_q";
 immutable schemaVersionTable = "schema_version";
 immutable srcCovInfoTable = "src_cov_info";
+immutable srcCovImportedLineTable = "src_cov_imported_line";
 immutable srcCovTable = "src_cov_instr";
 immutable srcCovTimeStampTable = "src_cov_timestamp";
 immutable srcMetadataTable = "src_metadata";
@@ -672,6 +673,25 @@ struct CoverageInfoTable {
     bool status;
 }
 
+/** Imported line-based coverage data.
+ * It is used to preserve gcov line precision for reporting and mutation
+ * propagation while keeping the existing region-based coverage tables for the
+ * built-in coverage runtime.
+ */
+@TableName(srcCovImportedLineTable)
+@TableForeignKey("file_id", KeyRef("files(id)"), KeyParam("ON DELETE CASCADE"))
+@TableConstraint("file_line UNIQUE (file_id, line)")
+struct CoverageImportedLineTable {
+    long id;
+
+    @ColumnName("file_id")
+    long fileId;
+
+    uint line;
+
+    bool status;
+}
+
 /// When the coverage information was gathered.
 @TableName(srcCovTimeStampTable)
 struct CoverageTimeTtampTable {
@@ -876,7 +896,8 @@ void upgradeV0(ref Miniorm db) {
             RuntimeHistoryTable,
             MutationScoreHistoryTable,
             MutationFileScoreHistoryTable, TestFilesTable, CoverageCodeRegionTable,
-            CoverageInfoTable, CoverageTimeTtampTable, DependencyFileTable,
+            CoverageInfoTable, CoverageImportedLineTable, CoverageTimeTtampTable,
+            DependencyFileTable,
             DependencyRootTable, DextoolVersionTable, ConfigVersionTable,
             TestCmdOriginalTable,
             TestCmdMutatedTable,
@@ -2265,6 +2286,10 @@ void upgradeV61(ref Miniorm db) {
 
 void upgradeV62(ref Miniorm db) {
     db.run(buildSchema!ConfigVersionTable);
+}
+
+void upgradeV63(ref Miniorm db) {
+    db.run(buildSchema!CoverageImportedLineTable);
 }
 
 void replaceTbl(ref Miniorm db, string src, string dst) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -2184,26 +2184,6 @@ struct DbCoverage {
         return rval;
     }
 
-    bool hasImportedLineCoverage(FileId fileId) @trusted {
-        static immutable sql = "SELECT count(*) FROM " ~ srcCovImportedLineTable
-            ~ " WHERE file_id = :fid LIMIT 1";
-        auto stmt = db.prepare(sql);
-        stmt.get.bind(":fid", fileId.get);
-
-        foreach (ref r; stmt.get.execute)
-            return r.peek!long(0) > 0;
-        return false;
-    }
-
-    bool hasImportedLineCoverage() @trusted {
-        static immutable sql = "SELECT count(*) FROM " ~ srcCovImportedLineTable ~ " LIMIT 1";
-        auto stmt = db.prepare(sql);
-
-        foreach (ref r; stmt.get.execute)
-            return r.peek!long(0) > 0;
-        return false;
-    }
-
     long getCoverageMapCount() @trusted {
         static immutable sql = "SELECT count(*) FROM " ~ srcCovTable;
         auto stmt = db.prepare(sql);
@@ -2290,7 +2270,8 @@ struct DbCoverage {
 
         Set!MutationStatusId seen;
         auto app = appender!(MutationStatusId[])();
-        foreach (sql; [importedLineSql, regionSql]) {
+
+        void appendUnseenMutationIds(string sql) {
             auto stmt = db.prepare(sql);
             foreach (ref r; stmt.get.execute) {
                 const id = MutationStatusId(r.peek!long(0));
@@ -2300,6 +2281,9 @@ struct DbCoverage {
                 }
             }
         }
+
+        appendUnseenMutationIds(importedLineSql);
+        appendUnseenMutationIds(regionSql);
 
         return app.data;
     }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -2171,6 +2171,39 @@ struct DbCoverage {
         return rval.data;
     }
 
+    bool[uint] getImportedLineCoverage(FileId fileId) @trusted {
+        static immutable sql = "SELECT line, status FROM " ~ srcCovImportedLineTable
+            ~ " WHERE file_id = :fid";
+        auto stmt = db.prepare(sql);
+        stmt.get.bind(":fid", fileId.get);
+
+        typeof(return) rval;
+        foreach (ref r; stmt.get.execute) {
+            rval[cast(uint) r.peek!long(0)] = r.peek!bool(1);
+        }
+        return rval;
+    }
+
+    bool hasImportedLineCoverage(FileId fileId) @trusted {
+        static immutable sql = "SELECT count(*) FROM " ~ srcCovImportedLineTable
+            ~ " WHERE file_id = :fid LIMIT 1";
+        auto stmt = db.prepare(sql);
+        stmt.get.bind(":fid", fileId.get);
+
+        foreach (ref r; stmt.get.execute)
+            return r.peek!long(0) > 0;
+        return false;
+    }
+
+    bool hasImportedLineCoverage() @trusted {
+        static immutable sql = "SELECT count(*) FROM " ~ srcCovImportedLineTable ~ " LIMIT 1";
+        auto stmt = db.prepare(sql);
+
+        foreach (ref r; stmt.get.execute)
+            return r.peek!long(0) > 0;
+        return false;
+    }
+
     long getCoverageMapCount() @trusted {
         static immutable sql = "SELECT count(*) FROM " ~ srcCovTable;
         auto stmt = db.prepare(sql);
@@ -2192,11 +2225,27 @@ struct DbCoverage {
         stmt.get.execute;
     }
 
+    void clearImportedLineCoverage() @trusted {
+        static immutable sql = "DELETE FROM " ~ srcCovImportedLineTable;
+        auto stmt = db.prepare(sql);
+        stmt.get.execute;
+    }
+
     void putCoverageInfo(const CoverageRegionId regionId, bool status) {
         static immutable sql = "INSERT OR REPLACE INTO " ~ srcCovInfoTable
             ~ " (id, status) VALUES(:id, :status)";
         auto stmt = db.prepare(sql);
         stmt.get.bind(":id", regionId.get);
+        stmt.get.bind(":status", status);
+        stmt.get.execute;
+    }
+
+    void putImportedLineCoverage(const FileId fileId, uint line, bool status) {
+        static immutable sql = "INSERT OR REPLACE INTO " ~ srcCovImportedLineTable
+            ~ " (file_id, line, status) VALUES(:fid, :line, :status)";
+        auto stmt = db.prepare(sql);
+        stmt.get.bind(":fid", fileId.get);
+        stmt.get.bind(":line", line);
         stmt.get.bind(":status", status);
         stmt.get.execute;
     }
@@ -2221,18 +2270,35 @@ struct DbCoverage {
     }
 
     MutationStatusId[] getNotCoveredMutants() @trusted {
-        static immutable sql = format!"SELECT DISTINCT t3.st_id FROM %1$s t0, %2$s t1, %3$s t2, %4$s t3
+        static immutable importedLineSql = format!"SELECT DISTINCT t1.st_id FROM %1$s t0, %2$s t1
+            WHERE t0.id = t1.mp_id AND
+            EXISTS (SELECT 1 FROM %3$s t2 WHERE t2.file_id = t0.file_id) AND
+            EXISTS (SELECT 1 FROM %3$s t2 WHERE t2.file_id = t0.file_id
+                AND t2.line BETWEEN t0.line AND t0.line_end) AND
+            NOT EXISTS (SELECT 1 FROM %3$s t2 WHERE t2.file_id = t0.file_id
+                AND t2.line BETWEEN t0.line AND t0.line_end AND t2.status = 1)"
+            (mutationPointTable, mutationTable, srcCovImportedLineTable);
+        static immutable regionSql = format!"SELECT DISTINCT t3.st_id FROM %1$s t0, %2$s t1, %3$s t2, %4$s t3
             WHERE t0.status = 0 AND
             t0.id = t1.id AND
             t1.file_id = t2.file_id AND
+            NOT EXISTS (SELECT 1 FROM %5$s t4 WHERE t4.file_id = t2.file_id) AND
             (t2.offset_begin BETWEEN t1.begin AND t1.end) AND
             (t2.offset_end BETWEEN t1.begin AND t1.end) AND
-            t2.id = t3.mp_id"(srcCovInfoTable, srcCovTable, mutationPointTable, mutationTable);
+            t2.id = t3.mp_id"(srcCovInfoTable, srcCovTable, mutationPointTable,
+                    mutationTable, srcCovImportedLineTable);
 
+        Set!MutationStatusId seen;
         auto app = appender!(MutationStatusId[])();
-        auto stmt = db.prepare(sql);
-        foreach (ref r; stmt.get.execute) {
-            app.put(MutationStatusId(r.peek!long(0)));
+        foreach (sql; [importedLineSql, regionSql]) {
+            auto stmt = db.prepare(sql);
+            foreach (ref r; stmt.get.execute) {
+                const id = MutationStatusId(r.peek!long(0));
+                if (!seen.contains(id)) {
+                    seen.add(id);
+                    app.put(id);
+                }
+            }
         }
 
         return app.data;

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/database/standalone.d
@@ -2186,6 +2186,12 @@ struct DbCoverage {
         stmt.get.execute;
     }
 
+    void clearCoverageInfo() @trusted {
+        static immutable sql = "DELETE FROM " ~ srcCovInfoTable;
+        auto stmt = db.prepare(sql);
+        stmt.get.execute;
+    }
+
     void putCoverageInfo(const CoverageRegionId regionId, bool status) {
         static immutable sql = "INSERT OR REPLACE INTO " ~ srcCovInfoTable
             ~ " (id, status) VALUES(:id, :status)";

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
@@ -776,9 +776,6 @@ void generateFile(ref Database db, ref FileCtx ctx) @trusted {
     // newlines, detect when a line changes etc.
     auto lastLoc = SourceLoc(1, 1);
 
-    // read coverage data and save covered lines in lineList
-    auto dbData = db.coverageApi.getCoverageStatus(ctx.fileId);
-
     void addMutantsTo_g_muts_data() {
         foreach (m; ctx.span.muts) {
             const metadata = db.mutantApi.getMutantMetaData(m.stId);
@@ -796,7 +793,14 @@ void generateFile(ref Database db, ref FileCtx ctx) @trusted {
     };
     addMutantsTo_g_muts_data();
 
-    auto lineList = extractLineCovData(dbData, ctx);
+    auto lineList = () {
+        auto importedLineData = db.coverageApi.getImportedLineCoverage(ctx.fileId);
+        if (importedLineData.length != 0)
+            return importedLineData;
+
+        auto dbData = db.coverageApi.getCoverageStatus(ctx.fileId);
+        return extractLineCovData(dbData, ctx);
+    }();
     void markCoverage(Element parent, int loc) {
         if (auto v = loc in lineList) {
             parent.firstChild.addClass((*v) ? "loc_covered" : "loc_noncovered");

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/coverage.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/coverage.d
@@ -382,6 +382,7 @@ nothrow:
         logger.info("Saving coverage data to database").collectException;
         void save() @trusted {
             auto trans = db.transaction;
+            db.coverageApi.clearImportedLineCoverage;
             foreach (a; data.covMap) {
                 db.coverageApi.putCoverageInfo(localId[a.id], a.status);
             }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/coverage.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/coverage.d
@@ -26,6 +26,8 @@ static import my.fsm;
 import dextool.plugin.mutate.backend.database : CovRegion, CoverageRegionId, FileId;
 import dextool.plugin.mutate.backend.database : Database;
 import dextool.plugin.mutate.backend.interface_ : FilesysIO, Blob;
+import dextool.plugin.mutate.backend.test_mutant.gcov_json : GcovImportStats,
+    importGcovJsonCoverage;
 import dextool.plugin.mutate.backend.test_mutant.test_cmd_runner : TestRunner, TestResult;
 import dextool.plugin.mutate.backend.type : Mutation, Language;
 import dextool.plugin.mutate.type : ShellCommand, UserRuntime, CoverageRuntime;
@@ -42,6 +44,9 @@ struct CoverageDriver {
 
     static struct InitializeRoots {
         bool hasRoot;
+    }
+
+    static struct ImportGcovJson {
     }
 
     static struct SaveOriginal {
@@ -71,8 +76,8 @@ struct CoverageDriver {
     static struct Done {
     }
 
-    alias Fsm = my.fsm.Fsm!(None, Initialize, InitializeRoots, SaveOriginal,
-            Instrument, Compile, Run, SaveToDb, Restore, Done);
+    alias Fsm = my.fsm.Fsm!(None, Initialize, ImportGcovJson, InitializeRoots,
+            SaveOriginal, Instrument, Compile, Run, SaveToDb, Restore, Done);
 
     private {
         Fsm fsm;
@@ -108,6 +113,8 @@ struct CoverageDriver {
         Set!AbsolutePath roots;
 
         CoverageRuntime runtime;
+        AbsolutePath[] gcovJson;
+        bool importExists;
     }
 
     this(FilesysIO fio, Database* db, TestRunner* runner, ConfigCoverage conf,
@@ -119,6 +126,7 @@ struct CoverageDriver {
         this.buildCmdTimeout = buildCmdTimeout;
         this.log = conf.log;
         this.runtime = conf.runtime;
+        this.gcovJson = conf.gcovJson;
 
         foreach (a; conf.userRuntimeCtrl) {
             auto p = fio.toAbsoluteRoot(a.file);
@@ -132,6 +140,14 @@ struct CoverageDriver {
 
     static void execute_(ref CoverageDriver self) @trusted {
         self.fsm.next!((None a) => Initialize.init, (Initialize a) {
+            if (!self.gcovJson.empty)
+                return fsm(ImportGcovJson.init);
+            if (self.runtime == CoverageRuntime.inject)
+                return fsm(InitializeRoots.init);
+            return fsm(SaveOriginal.init);
+        }, (ImportGcovJson a) {
+            if (self.importExists)
+                return fsm(Done.init);
             if (self.runtime == CoverageRuntime.inject)
                 return fsm(InitializeRoots.init);
             return fsm(SaveOriginal.init);
@@ -172,6 +188,21 @@ nothrow:
     }
 
     void opCall(None data) {
+    }
+
+    void opCall(ImportGcovJson data) {
+        try {
+            GcovImportStats stats = importGcovJsonCoverage(fio, db, gcovJson);
+            if (stats.imported) {
+                logger.infof("Imported gcov json coverage (%s inputs, %s source files, %s statuses)",
+                        stats.inputFiles, stats.sourceFiles, stats.regionStatuses)
+                    .collectException;
+                importExists = true;
+            }
+        } catch (Exception e) {
+            error_ = true;
+            logger.error(e.msg).collectException;
+        }
     }
 
     void opCall(Initialize data) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
@@ -19,7 +19,7 @@ import std.zlib : HeaderFormat, UnCompress;
 import miniorm;
 import my.optional;
 
-import dextool.plugin.mutate.backend.database : CoverageRegionId;
+import dextool.plugin.mutate.backend.database : CoverageRegionId, FileId;
 import dextool.plugin.mutate.backend.database : Database;
 import dextool.plugin.mutate.backend.interface_ : FilesysIO;
 import dextool.plugin.mutate.backend.type : Offset;
@@ -36,6 +36,12 @@ struct GcovImportStats {
 
 private struct ImportedRegionStatus {
     CoverageRegionId id;
+    bool status;
+}
+
+private struct ImportedLineStatus {
+    FileId fileId;
+    uint line;
     bool status;
 }
 
@@ -200,6 +206,7 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
     }
 
     const inputs = inputFiles.data;
+    spinSql!(() => db.coverageApi.clearImportedLineCoverage);
     if (inputs.length == 0)
         logger.warning("No gcov json input files were found").collectException;
     if (inputs.length == 0)
@@ -215,6 +222,7 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
     }
 
     auto importedStatuses = appender!(ImportedRegionStatus[])();
+    auto importedLines = appender!(ImportedLineStatus[])();
     size_t matchedFiles;
 
     foreach (entry; regionsByFile.byKeyValue) {
@@ -226,6 +234,10 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
             auto raw = fio.makeInput(fio.toAbsoluteRoot(relPath.get)).content;
             const starts = lineStarts(raw);
             matchedFiles++;
+
+            foreach (lineEntry; lineCounts.byKeyValue) {
+                importedLines.put(ImportedLineStatus(entry.key, lineEntry.key, lineEntry.value > 0));
+            }
 
             foreach (region; entry.value) {
                 auto status = statusForRegion(region.region, starts, *lineCounts);
@@ -245,6 +257,9 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
     spinSql!(() @trusted {
         auto trans = db.transaction;
         db.coverageApi.clearCoverageInfo;
+        foreach (entry; importedLines.data) {
+            db.coverageApi.putImportedLineCoverage(entry.fileId, entry.line, entry.status);
+        }
         foreach (entry; importedStatuses.data) {
             db.coverageApi.putCoverageInfo(entry.id, entry.status);
         }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
@@ -1,0 +1,256 @@
+/**
+Copyright: Copyright (c) 2026, Joakim Brännström. All rights reserved.
+License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0)
+Author: Joakim Brännström (joakim.brannstrom@gmx.com)
+*/
+module dextool.plugin.mutate.backend.test_mutant.gcov_json;
+
+import std.algorithm : filter, map;
+import std.array : appender, array;
+import logger = std.experimental.logger;
+import std.exception : collectException, ifThrown;
+import std.file : dirEntries, exists, isDir, read, readText, SpanMode;
+import std.json : JSONException, JSONOptions, JSONValue, parseJSON;
+import std.path : buildPath, isAbsolute;
+import std.range : assumeSorted;
+import std.string : endsWith;
+import std.zlib : HeaderFormat, UnCompress;
+
+import miniorm;
+import my.optional;
+
+import dextool.plugin.mutate.backend.database : CoverageRegionId;
+import dextool.plugin.mutate.backend.database : Database;
+import dextool.plugin.mutate.backend.interface_ : FilesysIO;
+import dextool.plugin.mutate.backend.type : Offset;
+import dextool.type : AbsolutePath, Path;
+
+@safe:
+
+struct GcovImportStats {
+    size_t inputFiles;
+    size_t sourceFiles;
+    size_t regionStatuses;
+    bool imported;
+}
+
+private struct ImportedRegionStatus {
+    CoverageRegionId id;
+    bool status;
+}
+
+private string readGcovJson(AbsolutePath path) @trusted {
+    if (!path.toString.endsWith(".gz"))
+        return readText(path.toString);
+
+    scope decmp = new UnCompress(HeaderFormat.gzip);
+    auto app = appender!(ubyte[])();
+    app.put(cast(const(ubyte)[]) decmp.uncompress(read(path.toString)));
+    app.put(cast(const(ubyte)[]) decmp.flush());
+    return cast(string) app.data.idup;
+}
+
+private long jsonToLong(ref const(JSONValue) value) {
+    try {
+        return value.integer;
+    } catch (JSONException e) {
+        import std.conv : to;
+
+        return value.str.to!long;
+    }
+}
+
+private AbsolutePath resolveSourcePath(string path, string gcovCwd, AbsolutePath input) {
+    if (path.isAbsolute)
+        return AbsolutePath(path);
+    if (gcovCwd.length != 0)
+        return AbsolutePath(buildPath(gcovCwd, path));
+    return AbsolutePath(buildPath(input.dirName.toString, path));
+}
+
+private void addLineCoverage(ref long[uint][Path] lineCoverage, Path source, uint lineNumber,
+        long count) {
+    if (auto fileCoverage = source in lineCoverage) {
+        if (auto existing = lineNumber in *fileCoverage) {
+            *existing += count;
+        } else {
+            (*fileCoverage)[lineNumber] = count;
+        }
+    } else {
+        lineCoverage[source] = [lineNumber: count];
+    }
+}
+
+private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] inputs) {
+    long[uint][Path] lineCoverage;
+
+    foreach (input; inputs) {
+        JSONValue json;
+        try {
+            json = parseJSON(readGcovJson(input), JSONOptions.doNotEscapeSlashes);
+        } catch (Exception e) {
+            logger.warningf("Failed to parse gcov json %s: %s", input, e.msg).collectException;
+            continue;
+        }
+
+        const gcovCwd = ifThrown(json["current_working_directory"].str, string.init);
+
+        JSONValue files;
+        try {
+            files = json["files"];
+        } catch (Exception e) {
+            logger.warningf("Object 'files' not found in gcov json %s", input).collectException;
+            continue;
+        }
+
+        foreach (fileEntry; files.arrayNoRef) {
+            try {
+                const source = resolveSourcePath(fileEntry["file"].str, gcovCwd, input);
+                auto relSource = fio.toRelativeRoot(Path(source.toString));
+                foreach (lineEntry; fileEntry["lines"].arrayNoRef) {
+                    const lineNumber = cast(uint) jsonToLong(lineEntry["line_number"]);
+                    const count = jsonToLong(lineEntry["count"]);
+                    addLineCoverage(lineCoverage, relSource, lineNumber, count);
+                }
+            } catch (Exception e) {
+                logger.warningf("Skipping malformed gcov file entry in %s: %s", input, e.msg)
+                    .collectException;
+            }
+        }
+    }
+
+    return lineCoverage;
+}
+
+private uint[] lineStarts(const(ubyte)[] content) {
+    auto starts = appender!(uint[])();
+    starts.put(0);
+    foreach (i, b; content) {
+        if (b == '\n' && i + 1 < content.length)
+            starts.put(cast(uint)(i + 1));
+    }
+    return starts.data;
+}
+
+private uint lineNumberAt(const uint[] starts, uint offset) @safe pure nothrow {
+    if (starts.length == 0)
+        return 1;
+    return cast(uint)(starts.length - assumeSorted(starts).upperBound(offset).length);
+}
+
+private Optional!bool statusForRegion(const Offset region, const uint[] starts, const long[uint] lineCounts) {
+    const beginLine = lineNumberAt(starts, region.begin);
+    const endLine = lineNumberAt(starts, region.isZero ? region.begin : region.end - 1);
+
+    bool sawLine;
+    bool covered;
+    foreach (line; beginLine .. endLine + 1) {
+        if (auto count = line in lineCounts) {
+            sawLine = true;
+            covered = covered || *count > 0;
+        }
+    }
+
+    if (!sawLine)
+        return none!bool;
+
+    return some(covered);
+}
+
+GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
+        const AbsolutePath[] rawInputs) @trusted {
+    bool isGcovJsonFile(string path) @safe pure nothrow {
+        return path.endsWith(".gcov.json") || path.endsWith(".gcov.json.gz");
+    }
+
+    AbsolutePath[] findAllGcovJson(AbsolutePath inputDir) {
+        if (!isDir(inputDir))
+            return typeof(return).init;
+
+        auto gcovFiles = dirEntries(inputDir.toString, SpanMode.depth)
+            .filter!(a => !a.isDir && isGcovJsonFile(a.name))
+            .map!(a => AbsolutePath(a.name))
+            .array;
+
+        if (gcovFiles.length == 0)
+            logger.warningf("No gcov json files found in %s", inputDir).collectException;
+
+        return gcovFiles;
+    }
+
+    auto inputFiles = appender!(AbsolutePath[])();
+    foreach (rawInput; rawInputs) {
+        if (!exists(rawInput)) {
+            logger.warningf("gcov json input does not exist: %s", rawInput).collectException;
+            continue;
+        }
+
+        if (isDir(rawInput)) {
+            inputFiles.put(findAllGcovJson(rawInput));
+            continue;
+        }
+
+        if (!isGcovJsonFile(rawInput.toString)) {
+            logger.warningf("gcov json input must end in .gcov.json or .gcov.json.gz: %s",
+                    rawInput).collectException;
+            continue;
+        }
+
+        inputFiles.put(rawInput);
+    }
+
+    const inputs = inputFiles.data;
+    if (inputs.length == 0)
+        logger.warning("No gcov json input files were found").collectException;
+    if (inputs.length == 0)
+        return GcovImportStats(0, 0, 0, false);
+
+    auto importedCoverage = loadLineCoverage(fio, inputs);
+    auto regionsByFile = spinSql!(() => db.coverageApi.getCoverageMap);
+    if (regionsByFile.length == 0) {
+        logger.warning(
+                "No analyzed coverage regions found. Re-run analyze with [coverage].use = true before importing gcov JSON.")
+            .collectException;
+        return GcovImportStats(inputs.length, 0, 0, false);
+    }
+
+    auto importedStatuses = appender!(ImportedRegionStatus[])();
+    size_t matchedFiles;
+
+    foreach (entry; regionsByFile.byKeyValue) {
+        auto relPath = spinSql!(() => db.getFile(entry.key));
+        if (relPath.isNull)
+            continue;
+
+        if (auto lineCounts = relPath.get in importedCoverage) {
+            auto raw = fio.makeInput(fio.toAbsoluteRoot(relPath.get)).content;
+            const starts = lineStarts(raw);
+            matchedFiles++;
+
+            foreach (region; entry.value) {
+                auto status = statusForRegion(region.region, starts, *lineCounts);
+                if (status.hasValue)
+                    importedStatuses.put(ImportedRegionStatus(region.id, status.orElse(false)));
+            }
+        }
+    }
+
+    if (matchedFiles == 0) {
+        logger.warning(
+                "None of the gcov json files matched analyzed source files in the current work area.")
+            .collectException;
+        return GcovImportStats(inputs.length, 0, 0, false);
+    }
+
+    spinSql!(() @trusted {
+        auto trans = db.transaction;
+        db.coverageApi.clearCoverageInfo;
+        foreach (entry; importedStatuses.data) {
+            db.coverageApi.putCoverageInfo(entry.id, entry.status);
+        }
+        db.coverageApi.updateCoverageTimeStamp;
+        trans.commit;
+    });
+
+    return GcovImportStats(inputs.length, matchedFiles, importedStatuses.data.length, true);
+}

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
@@ -56,39 +56,38 @@ private string readGcovJson(AbsolutePath path) @trusted {
     return cast(string) app.data.idup;
 }
 
-private long jsonToLong(ref const(JSONValue) value) {
-    try {
-        return value.integer;
-    } catch (JSONException e) {
-        import std.conv : to;
-
-        return value.str.to!long;
-    }
-}
-
-private AbsolutePath resolveSourcePath(string path, string gcovCwd, AbsolutePath input) {
-    if (path.isAbsolute)
-        return AbsolutePath(path);
-    if (gcovCwd.length != 0)
-        return AbsolutePath(buildPath(gcovCwd, path));
-    return AbsolutePath(buildPath(input.dirName.toString, path));
-}
-
-private void addLineCoverage(ref long[uint][Path] lineCoverage, Path source, uint lineNumber,
-        long count) {
-    if (auto fileCoverage = source in lineCoverage) {
-        if (auto existing = lineNumber in *fileCoverage) {
-            *existing += count;
-        } else {
-            (*fileCoverage)[lineNumber] = count;
-        }
-    } else {
-        lineCoverage[source] = [lineNumber: count];
-    }
-}
-
 private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] inputs) {
     long[uint][Path] lineCoverage;
+
+    long jsonToLong(ref const(JSONValue) value) {
+        try {
+            return value.integer;
+        } catch (JSONException e) {
+            import std.conv : to;
+
+            return value.str.to!long;
+        }
+    }
+
+    AbsolutePath resolveSourcePath(string path, string gcovCwd, AbsolutePath input) {
+        if (path.isAbsolute)
+            return AbsolutePath(path);
+        if (gcovCwd.length != 0)
+            return AbsolutePath(buildPath(gcovCwd, path));
+        return AbsolutePath(buildPath(input.dirName.toString, path));
+    }
+
+    void addLineCoverage(Path source, uint lineNumber, long count) {
+        if (auto fileCoverage = source in lineCoverage) {
+            if (auto existing = lineNumber in *fileCoverage) {
+                *existing += count;
+            } else {
+                (*fileCoverage)[lineNumber] = count;
+            }
+        } else {
+            lineCoverage[source] = [lineNumber: count];
+        }
+    }
 
     foreach (input; inputs) {
         JSONValue json;
@@ -125,7 +124,7 @@ private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] in
                 foreach (lineEntry; fileEntry["lines"].arrayNoRef) {
                     const lineNumber = cast(uint) jsonToLong(lineEntry["line_number"]);
                     const count = jsonToLong(lineEntry["count"]);
-                    addLineCoverage(lineCoverage, relSource, lineNumber, count);
+                    addLineCoverage(relSource, lineNumber, count);
                 }
             } catch (Exception e) {
                 logger.warningf("Skipping malformed gcov file entry in %s: %s", input, e.msg)
@@ -147,15 +146,15 @@ private uint[] lineStarts(const(ubyte)[] content) {
     return starts.data;
 }
 
-private uint lineNumberAt(const uint[] starts, uint offset) @safe pure nothrow {
-    if (starts.length == 0)
-        return 1;
-    return cast(uint)(starts.length - assumeSorted(starts).upperBound(offset).length);
-}
-
 private Optional!bool statusForRegion(const Offset region, const uint[] starts, const long[uint] lineCounts) {
-    const beginLine = lineNumberAt(starts, region.begin);
-    const endLine = lineNumberAt(starts, region.isZero ? region.begin : region.end - 1);
+    uint lineNumberAt(uint offset) {
+        if (starts.length == 0)
+            return 1;
+        return cast(uint)(starts.length - assumeSorted(starts).upperBound(offset).length);
+    }
+
+    const beginLine = lineNumberAt(region.begin);
+    const endLine = lineNumberAt(region.isZero ? region.begin : region.end - 1);
 
     bool sawLine;
     bool covered;
@@ -230,33 +229,46 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
         return GcovImportStats(inputs.length, 0, 0, false);
     }
 
-    auto importedStatuses = appender!(ImportedRegionStatus[])();
-    auto importedLines = appender!(ImportedLineStatus[])();
-    size_t matchedFiles;
-
-    foreach (entry; regionsByFile.byKeyValue) {
-        auto relPath = spinSql!(() => db.getFile(entry.key));
-        if (relPath.isNull)
-            continue;
-
-        if (auto lineCounts = relPath.get in importedCoverage) {
-            auto raw = fio.makeInput(fio.toAbsoluteRoot(relPath.get)).content;
-            const starts = lineStarts(raw);
-            matchedFiles++;
-
-            foreach (lineEntry; lineCounts.byKeyValue) {
-                importedLines.put(ImportedLineStatus(entry.key, lineEntry.key, lineEntry.value > 0));
-            }
-
-            foreach (region; entry.value) {
-                auto status = statusForRegion(region.region, starts, *lineCounts);
-                if (status.hasValue)
-                    importedStatuses.put(ImportedRegionStatus(region.id, status.orElse(false)));
-            }
-        }
+    struct ImportedCoverageMatch {
+        size_t matchedFiles;
+        ImportedLineStatus[] lines;
+        ImportedRegionStatus[] statuses;
     }
 
-    if (matchedFiles == 0) {
+    ImportedCoverageMatch matchImportedCoverage() {
+        auto importedStatuses = appender!(ImportedRegionStatus[])();
+        auto importedLines = appender!(ImportedLineStatus[])();
+        size_t matchedFiles;
+
+        foreach (entry; regionsByFile.byKeyValue) {
+            auto relPath = spinSql!(() => db.getFile(entry.key));
+            if (relPath.isNull)
+                continue;
+
+            if (auto lineCounts = relPath.get in importedCoverage) {
+                auto raw = fio.makeInput(fio.toAbsoluteRoot(relPath.get)).content;
+                const starts = lineStarts(raw);
+                matchedFiles++;
+
+                foreach (lineEntry; lineCounts.byKeyValue) {
+                    importedLines.put(ImportedLineStatus(entry.key, lineEntry.key,
+                            lineEntry.value > 0));
+                }
+
+                foreach (region; entry.value) {
+                    auto status = statusForRegion(region.region, starts, *lineCounts);
+                    if (status.hasValue)
+                        importedStatuses.put(ImportedRegionStatus(region.id,
+                                status.orElse(false)));
+                }
+            }
+        }
+
+        return ImportedCoverageMatch(matchedFiles, importedLines.data, importedStatuses.data);
+    }
+
+    auto matchedCoverage = matchImportedCoverage();
+    if (matchedCoverage.matchedFiles == 0) {
         logger.warning(
                 "None of the gcov json files matched analyzed source files in the current work area.")
             .collectException;
@@ -266,15 +278,16 @@ GcovImportStats importGcovJsonCoverage(FilesysIO fio, Database* db,
     spinSql!(() @trusted {
         auto trans = db.transaction;
         db.coverageApi.clearCoverageInfo;
-        foreach (entry; importedLines.data) {
+        foreach (entry; matchedCoverage.lines) {
             db.coverageApi.putImportedLineCoverage(entry.fileId, entry.line, entry.status);
         }
-        foreach (entry; importedStatuses.data) {
+        foreach (entry; matchedCoverage.statuses) {
             db.coverageApi.putCoverageInfo(entry.id, entry.status);
         }
         db.coverageApi.updateCoverageTimeStamp;
         trans.commit;
     });
 
-    return GcovImportStats(inputs.length, matchedFiles, importedStatuses.data.length, true);
+    return GcovImportStats(inputs.length, matchedCoverage.matchedFiles,
+            matchedCoverage.statuses.length, true);
 }

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
@@ -89,6 +89,16 @@ private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] in
         }
     }
 
+    long nonNegativeCount(long count, AbsolutePath source, uint lineNumber, string dataFile) {
+        if (count >= 0)
+            return count;
+
+        logger.warningf(
+                "(negative) Unexpected negative hit count '%s' for line %s:%s while importing from %s.",
+                count, source, lineNumber, dataFile).collectException;
+        return 0;
+    }
+
     foreach (input; inputs) {
         JSONValue json;
         try {
@@ -99,6 +109,7 @@ private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] in
         }
 
         const gcovCwd = ifThrown(json["current_working_directory"].str, string.init);
+        const dataFile = ifThrown(json["data_file"].str, input.toString);
 
         JSONValue files;
         try {
@@ -123,7 +134,8 @@ private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] in
                 auto relSource = fio.toRelativeRoot(Path(source.toString));
                 foreach (lineEntry; fileEntry["lines"].arrayNoRef) {
                     const lineNumber = cast(uint) jsonToLong(lineEntry["line_number"]);
-                    const count = jsonToLong(lineEntry["count"]);
+                    const count = nonNegativeCount(jsonToLong(lineEntry["count"]), source,
+                            lineNumber, dataFile);
                     addLineCoverage(relSource, lineNumber, count);
                 }
             } catch (Exception e) {

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/gcov_json.d
@@ -109,7 +109,16 @@ private long[uint][Path] loadLineCoverage(FilesysIO fio, const AbsolutePath[] in
             continue;
         }
 
-        foreach (fileEntry; files.arrayNoRef) {
+        JSONValue[] fileEntries;
+        try {
+            fileEntries = files.arrayNoRef;
+        } catch (Exception e) {
+            logger.warningf("Object 'files' in gcov json %s must be an array: %s", input, e.msg)
+                .collectException;
+            continue;
+        }
+
+        foreach (fileEntry; fileEntries) {
             try {
                 const source = resolveSourcePath(fileEntry["file"].str, gcovCwd, input);
                 auto relSource = fio.toRelativeRoot(Path(source.toString));

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/test_mutant/package.d
@@ -1569,9 +1569,11 @@ nothrow:
         auto covTimeStamp = spinSql!(() => db.coverageApi.getCoverageTimeStamp).orElse(
                 SysTime.init);
 
-        if (tracked < covTimeStamp) {
+        if (tracked < covTimeStamp && covConf.gcovJson.empty) {
             logger.info("Coverage information is up to date").collectException;
             return;
+        } else if (!covConf.gcovJson.empty) {
+            logger.info("Importing coverage from gcov --json-format").collectException;
         } else {
             logger.infof("Coverage is out of date with SUT/tests (%s < %s)",
                     covTimeStamp, tracked).collectException;

--- a/plugin/mutate/source/dextool/plugin/mutate/config.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/config.d
@@ -339,6 +339,9 @@ struct ConfigCoverage {
     /// If the generated coverage files should be saved.
     bool log;
 
+    /// Import coverage from gcov --json-format output files or directories.
+    AbsolutePath[] gcovJson;
+
     /// allows a user to control exactly which files the coverage and schemata
     /// runtime is injected in.
     UserRuntime[] userRuntimeCtrl;

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -717,6 +717,9 @@ struct ArgParser {
                 analyze.rawTestExclude.map!(a => buildPath(workArea.root, a)).array);
 
         compiler.extraFlags = compiler.extraFlags ~ args.find("--").drop(1).array();
+
+        if (!coverage.gcovJson.empty)
+            coverage.use = true;
     }
 
     /**
@@ -1522,6 +1525,33 @@ gcov_json = ["foo.gcov.json.gz", "coverage"]
         AbsolutePath("foo.gcov.json.gz"),
         AbsolutePath("coverage")
     ]);
+}
+
+@("shall enable coverage use when gcov json coverage is configured")
+@system unittest {
+    import toml : parseTOML;
+
+    immutable txt = `
+[coverage]
+gcov_json = "foo.gcov.json.gz"
+`;
+    auto doc = parseTOML(txt);
+    auto ap = loadConfig(ArgParser.make, doc);
+
+    ap.parse(["dextool", "test"]);
+
+    ap.coverage.use.shouldBeTrue;
+    ap.coverage.gcovJson.shouldEqual([AbsolutePath("foo.gcov.json.gz")]);
+}
+
+@("shall enable coverage use when gcov json coverage is provided by cli")
+@system unittest {
+    auto ap = ArgParser.make;
+
+    ap.parse(["dextool", "test", "--gcov-json", "foo.gcov.json"]);
+
+    ap.coverage.use.shouldBeTrue;
+    ap.coverage.gcovJson.shouldEqual([AbsolutePath("foo.gcov.json")]);
 }
 
 @("shall parse the report sections")

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -197,18 +197,27 @@ struct ArgParser {
         app.put("# Use coverage to reduce the tested mutants");
         app.put("use = true");
         app.put(null);
-        app.put("# how to add the coverage runtime to the SUT");
+        app.put("# how to add the built-in coverage runtime to the SUT");
         app.put(format!"# available options are: %(%s, %)"(
                 [EnumMembers!CoverageRuntime].map!(a => a.to!string)));
         app.put("# runtime = inject");
         app.put(null);
         app.put(
-                "# Default is to inject the runtime in all roots. A root is a file either provided by --in");
+                "# Default is to inject the built-in runtime in all roots. A root is a file either provided by --in");
         app.put("# or a file in compile_commands.json.");
         app.put(
                 "# If specified then the coverage and schemata runtime is only injected in these files.");
         app.put("# paths are relative to root.");
         app.put(`# inject_runtime_impl = [["file1.c", "c"], ["file2.c", "cpp"]]`);
+        app.put(null);
+        app.put("# import coverage from gcov --json-format output");
+        app.put("# Use this when your build system already produces gcov data;");
+        app.put("# otherwise dextool gathers coverage with its built-in source instrumentation.");
+        app.put("# entries may be files or directories containing gcov json artifacts.");
+        app.put(`# 1. ["./build"]`);
+        app.put(`# 2. ["./build/file.gcov.json.gz"]`);
+        app.put(`# 3. ["./build/file1.gcov.json", "./build/file2.gcov.json"]`);
+        app.put(`# gcov_json = ["./build"]`);
         app.put(null);
 
         app.put("[database]");
@@ -470,6 +479,7 @@ struct ArgParser {
             long mutationTesterRuntime;
             string maxRuntime;
             string mutationCompile;
+            string[] gcovJson;
             string[] mutationTestCaseAnalyze;
             string[] mutationTester;
             string[] testConstraint;
@@ -491,6 +501,7 @@ struct ArgParser {
                    "diff-from-stdin", "restrict testing to the mutants in the diff", &mutationTest.unifiedDiffFromStdin,
                    "dry-run", "do not write data to the filesystem", &mutationTest.dryRun,
                    "exclude", exclude_help, &workArea.rawExclude,
+                   "gcov-json", "import coverage from gcov --json-format files or directories", &gcovJson,
                    "include", include_help, &workArea.rawInclude,
                    "load-behavior", "how to behave when the threshold is hit " ~ format("[%(%s|%)]", [EnumMembers!(ConfigMutationTest.LoadBehavior)]), &mutationTest.loadBehavior,
                    "load-threshold", format!"the 15min loadavg threshold (default: %s)"(mutationTest.loadThreshold.get), mutationTest.loadThreshold.getPtr,
@@ -537,6 +548,8 @@ struct ArgParser {
             if (mutationTestCaseAnalyze.length != 0)
                 mutationTest.mutationTestCaseAnalyze = mutationTestCaseAnalyze.map!(
                         a => ShellCommand([a])).array;
+            if (!gcovJson.empty)
+                coverage.gcovJson = gcovJson.map!(a => AbsolutePath(a)).array;
             if (mutationTesterRuntime != 0)
                 mutationTest.mutationTesterRuntime = mutationTesterRuntime.dur!"msecs";
             if (!maxRuntime.empty)
@@ -1001,6 +1014,20 @@ ArgParser loadConfig(ArgParser rval, TOMLDocument doc) @trusted {
                 EnumMembers!CoverageRuntime
             ]);
             logger.warning(e.msg);
+        }
+    };
+    callbacks["coverage.gcov_json"] = (ref ArgParser c, ref TOMLValue v) {
+        try {
+            if (v.type == TOML_TYPE.STRING) {
+                c.coverage.gcovJson = [AbsolutePath(v.str)];
+            } else if (v.type == TOML_TYPE.ARRAY) {
+                c.coverage.gcovJson = v.array.map!(a => AbsolutePath(a.str)).array;
+            } else {
+                logger.error("coverage.gcov_json: failed parsing");
+            }
+        } catch (Exception e) {
+            logger.error("coverage.gcov_json: failed parsing");
+            logger.error(e.msg);
         }
     };
     callbacks["coverage.inject_runtime_impl"] = (ref ArgParser c, ref TOMLValue v) {
@@ -1478,6 +1505,22 @@ inject_runtime_impl = [["foo", "cpp"]]
     auto ap = loadConfig(ArgParser.init, doc);
     ap.coverage.userRuntimeCtrl.shouldEqual([
         UserRuntime(Path("foo"), Language.cpp)
+    ]);
+}
+
+@("shall parse the gcov json coverage inputs")
+@system unittest {
+    import toml : parseTOML;
+
+    immutable txt = `
+[coverage]
+gcov_json = ["foo.gcov.json.gz", "coverage"]
+`;
+    auto doc = parseTOML(txt);
+    auto ap = loadConfig(ArgParser.init, doc);
+    ap.coverage.gcovJson.shouldEqual([
+        AbsolutePath("foo.gcov.json.gz"),
+        AbsolutePath("coverage")
     ]);
 }
 

--- a/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/frontend/argparser.d
@@ -910,6 +910,18 @@ ArgParser loadConfig(ArgParser rval, TOMLDocument doc) @trusted {
         }
     }
 
+    static bool toGcovJsonInputs(ref TOMLValue v, ref AbsolutePath[] inputs) {
+        if (v.type == TOML_TYPE.STRING) {
+            inputs = [AbsolutePath(v.str)];
+            return true;
+        }
+        if (v.type == TOML_TYPE.ARRAY) {
+            inputs = v.array.map!(a => AbsolutePath(a.str)).array;
+            return true;
+        }
+        return false;
+    }
+
     static double toNumber(ref TOMLValue v, double default_, string errorMsg) nothrow {
         try {
             return v.floating;
@@ -1021,13 +1033,8 @@ ArgParser loadConfig(ArgParser rval, TOMLDocument doc) @trusted {
     };
     callbacks["coverage.gcov_json"] = (ref ArgParser c, ref TOMLValue v) {
         try {
-            if (v.type == TOML_TYPE.STRING) {
-                c.coverage.gcovJson = [AbsolutePath(v.str)];
-            } else if (v.type == TOML_TYPE.ARRAY) {
-                c.coverage.gcovJson = v.array.map!(a => AbsolutePath(a.str)).array;
-            } else {
+            if (!toGcovJsonInputs(v, c.coverage.gcovJson))
                 logger.error("coverage.gcov_json: failed parsing");
-            }
         } catch (Exception e) {
             logger.error("coverage.gcov_json: failed parsing");
             logger.error(e.msg);

--- a/plugin/mutate/test/test_coverage.d
+++ b/plugin/mutate/test/test_coverage.d
@@ -294,11 +294,6 @@ private string coverageHtmlProgramPage(ref TestEnv testEnv, CoverageFixutre fixt
             pathToHtmlName(filePath.get))).toString);
 }
 
-private void htmlLineShouldHaveCoverageClass(string html, uint line, string cssClass) {
-    html.canFind(format(`id="loc-%s"><span class="line_nr %s">%s:`, line, cssClass, line))
-        .shouldBeTrue;
-}
-
 private void assertCoverageInstrumentationOutput(string[] output) {
     testAnyOrder!SubStr([
         "Compiling instrumented source code",
@@ -398,11 +393,6 @@ private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixutre fixtu
     return view;
 }
 
-private bool[uint] loadImportedLineCoverage(ref TestEnv testEnv, CoverageFixutre fixture) {
-    auto db = openDatabase(testEnv);
-    return db.coverageApi.getImportedLineCoverage(coverageFileId(db, fixture));
-}
-
 private Mutation.Status[] mutantStatusesAtLine(ref TestEnv testEnv, CoverageFixutre fixture, uint line) {
     auto db = openDatabase(testEnv);
     static immutable sql = "SELECT DISTINCT t0.status FROM mutation_status t0, mutation t1, mutation_point t2 "
@@ -493,8 +483,14 @@ unittest {
     assertImportedCoverageOutput(testRun.output);
 
     const html = coverageHtmlProgramPage(testEnv, fixture);
-    htmlLineShouldHaveCoverageClass(html, 3, "loc_covered");
-    htmlLineShouldHaveCoverageClass(html, 5, "loc_noncovered");
+
+    void lineShouldHaveCoverageClass(uint line, string cssClass) {
+        html.canFind(format(`id="loc-%s"><span class="line_nr %s">%s:`, line, cssClass,
+                line)).shouldBeTrue;
+    }
+
+    lineShouldHaveCoverageClass(3, "loc_covered");
+    lineShouldHaveCoverageClass(5, "loc_noncovered");
 }
 
 @(testId ~ "shall use imported gcov line coverage when propagating no coverage mutants")
@@ -557,11 +553,16 @@ unittest {
             coverFunctionCoveredLines ~ mainFunctionCoveredLines,
             GcovJsonWriteOptions(gzip: true));
 
+    bool[uint] loadImportedLineCoverage() {
+        auto db = openDatabase(testEnv);
+        return db.coverageApi.getImportedLineCoverage(coverageFileId(db, fixture));
+    }
+
     analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
 
     runCoverageTest(testEnv, fixture, defaultCoverageConfig, [["--gcov-json", firstJson]]);
     auto firstCoverage = loadCoverageView(testEnv, fixture);
-    auto firstImportedCoverage = loadImportedLineCoverage(testEnv, fixture);
+    auto firstImportedCoverage = loadImportedLineCoverage();
     auto firstUncoveredLine = 57u in firstImportedCoverage;
     hasKnownStatus(firstCoverage, 57, 61, false).shouldBeTrue;
     (firstUncoveredLine !is null).shouldBeTrue;
@@ -574,7 +575,7 @@ unittest {
     assertImportedCoverageOutput(secondRun.output);
 
     auto secondCoverage = loadCoverageView(testEnv, fixture);
-    auto secondImportedCoverage = loadImportedLineCoverage(testEnv, fixture);
+    auto secondImportedCoverage = loadImportedLineCoverage();
     auto secondUncoveredLine = 57u in secondImportedCoverage;
     auto secondCoveredLine = 64u in secondImportedCoverage;
     hasKnownStatus(secondCoverage, 57, 61, false).shouldBeFalse;

--- a/plugin/mutate/test/test_coverage.d
+++ b/plugin/mutate/test/test_coverage.d
@@ -5,44 +5,734 @@ Author: Joakim Brännström (joakim.brannstrom@gmx.com)
 */
 module dextool_test.test_coverage;
 
-import core.thread : Thread;
-import core.time : dur, Duration;
-import std.algorithm : filter;
-import std.file : readText;
-import std.stdio : File;
-import std.traits : EnumMembers;
-import std.typecons : Yes;
+import std.algorithm : any, map;
+import std.array : appender, array;
+import std.file : mkdirRecurse, read, readText, write;
+import std.format : format;
+import std.json : JSONValue, parseJSON;
+import std.path : absolutePath, buildPath, relativePath;
+import std.range : assumeSorted;
+import std.zlib : Compress, HeaderFormat;
+
+import dextool.plugin.mutate.backend.type : ExitStatus, Mutation, Offset;
+import dextool.type : Path;
 
 import dextool_test.utility;
 import dextool_test.fixtures;
 
-class ShallUseCoverage : CoverageFixutre {
+private final class CoverageFixtureInstance : CoverageFixutre {
     override void test() {
-        import std.json;
-
-        mixin(EnvSetup(globalTestdir));
-        precondition(testEnv);
-
-        // dfmt off
-        makeDextoolAnalyze(testEnv)
-            .addInputArg(programCode)
-            .addPostArg(["--mutant", "all"])
-            .addPostArg(["-c", (testData ~ "config/coverage.toml").toString])
-            .run;
-
-        runDextoolTest(testEnv).run;
-
-        auto r =  makeDextoolReport(testEnv, testData.dirName)
-            .addPostArg(["--style", "json"])
-            .addPostArg(["--section", "summary", "--section", "all_mut"])
-            .addPostArg(["--logdir", testEnv.outdir.toString])
-            .run;
-        // dfmt on
-
-        // because different libclang versions result in different number of mutants...
-        auto j = parseJSON(readText((testEnv.outdir ~ "report.json").toString))["stat"];
-        j["alive"].integer.shouldBeGreaterThan(2);
-        j["killed"].integer.shouldBeGreaterThan(1);
-        j["no_coverage"].integer.shouldBeGreaterThan(1);
     }
+}
+
+private struct GcovLineSpec {
+    long lineNumber;
+    long count;
+    string functionName;
+}
+
+private struct GcovJsonWriteOptions {
+    string cwd = ".";
+    bool includeCwd = true;
+    bool includeFiles = true;
+    bool gzip;
+    bool stringifyNumbers;
+}
+
+private struct LineRange {
+    uint beginLine;
+    uint endLine;
+}
+
+private struct CoverageLineStatus {
+    LineRange lines;
+    bool status;
+}
+
+private struct CoverageView {
+    CoverageLineStatus[] known;
+    LineRange[] unknown;
+}
+
+private immutable GcovLineSpec[] coverFunctionCoveredLines = [
+    GcovLineSpec(47, 2, "cover"),
+    GcovLineSpec(48, 2, "cover"),
+    GcovLineSpec(49, 1, "cover"),
+    GcovLineSpec(51, 1, "cover"),
+    GcovLineSpec(54, 1, "cover")
+];
+
+private immutable GcovLineSpec[] coverFunctionCoveredLinesWithZeroCount = [
+    GcovLineSpec(47, 2, "cover"),
+    GcovLineSpec(48, 2, "cover"),
+    GcovLineSpec(49, 1, "cover"),
+    GcovLineSpec(51, 1, "cover"),
+    GcovLineSpec(52, 0, "cover"),
+    GcovLineSpec(54, 1, "cover")
+];
+
+private immutable GcovLineSpec[] unusedFunctionUncoveredLines = [
+    GcovLineSpec(57, 0, "unused"),
+    GcovLineSpec(58, 0, "unused"),
+    GcovLineSpec(59, 0, "unused"),
+    GcovLineSpec(61, 0, "unused")
+];
+
+private immutable GcovLineSpec[] mainFunctionCoveredLines = [
+    GcovLineSpec(64, 1, "main"),
+    GcovLineSpec(65, 1, "main"),
+    GcovLineSpec(66, 1, "main"),
+    GcovLineSpec(67, 1, "main"),
+    GcovLineSpec(68, 1, "main"),
+    GcovLineSpec(69, 1, "main")
+];
+
+private CoverageFixtureInstance setupCoverageFixture(ref TestEnv testEnv) {
+    auto fixture = new CoverageFixtureInstance;
+    fixture.precondition(testEnv);
+    return fixture;
+}
+
+private string defaultCoverageConfig() {
+    return (testData ~ "config/coverage.toml").toString;
+}
+
+private string writeConfig(ref TestEnv testEnv, string fileName, string content) {
+    const path = (testEnv.outdir ~ fileName).toString;
+    write(path, content);
+    return path;
+}
+
+private string coverageConfigText(string extraCoverage = "") {
+    const coverage = extraCoverage.length == 0 ? "use = true" : format("use = true\n%s",
+            extraCoverage);
+    return format(`[generic]
+mutants = ["lcr", "lcrb", "sdl", "uoi", "dcr"]
+
+[coverage]
+%s
+
+[mutant_test]
+test_cmd_timeout = "10 seconds"
+`, coverage);
+}
+
+private string analyzeWithoutCoverageConfigText() {
+    return `[generic]
+mutants = ["lcr", "lcrb", "sdl", "uoi", "dcr"]
+
+[mutant_test]
+test_cmd_timeout = "10 seconds"
+`;
+}
+
+private JSONValue makeGcovLine(GcovLineSpec spec,
+        GcovJsonWriteOptions options = GcovJsonWriteOptions()) {
+    JSONValue line;
+    JSONValue[] branches;
+    if (options.stringifyNumbers) {
+        line["line_number"] = format("%s", spec.lineNumber);
+        line["count"] = format("%s", spec.count);
+    } else {
+        line["line_number"] = spec.lineNumber;
+        line["count"] = spec.count;
+    }
+    line["function_name"] = spec.functionName;
+    line["unexecuted_block"] = spec.count == 0;
+    line["branches"] = JSONValue(branches);
+    return line;
+}
+
+private JSONValue makeGcovFileData(string sourceFile, const(GcovLineSpec)[] lines,
+        GcovJsonWriteOptions options = GcovJsonWriteOptions()) {
+    JSONValue fileData;
+    JSONValue[] functions;
+
+    fileData["file"] = sourceFile;
+    fileData["functions"] = JSONValue(functions);
+    fileData["lines"] = JSONValue(lines.map!(a => makeGcovLine(a, options)).array);
+    return fileData;
+}
+
+private void writeGcovJsonRoot(string path, JSONValue root, bool gzip) {
+    const content = root.toString;
+    if (!gzip) {
+        write(path, content);
+        return;
+    }
+
+    auto cmp = new Compress(HeaderFormat.gzip);
+    auto compressed = appender!(ubyte[])();
+    compressed.put(cast(const(ubyte)[]) cmp.compress(content));
+    compressed.put(cast(const(ubyte)[]) cmp.flush());
+    write(path, compressed.data);
+}
+
+private void writeGcovJsonFiles(string path, JSONValue[] files,
+        GcovJsonWriteOptions options = GcovJsonWriteOptions()) {
+    JSONValue root;
+
+    if (options.includeCwd)
+        root["current_working_directory"] = options.cwd;
+    root["data_file"] = "simple_coverage.gcda";
+    root["format_version"] = 1;
+    root["gcc_version"] = "13.0.0";
+    if (options.includeFiles)
+        root["files"] = JSONValue(files);
+
+    writeGcovJsonRoot(path, root, options.gzip);
+}
+
+private void writeGcovJson(string path, string sourceFile, const(GcovLineSpec)[] lines,
+        GcovJsonWriteOptions options = GcovJsonWriteOptions()) {
+    writeGcovJsonFiles(path, [makeGcovFileData(sourceFile, lines, options)], options);
+}
+
+private GcovLineSpec[] withCount(const(GcovLineSpec)[] lines, long count) {
+    return lines.map!(a => GcovLineSpec(a.lineNumber, count, a.functionName)).array;
+}
+
+private void analyzeCoverageProgram(ref TestEnv testEnv, CoverageFixtureInstance fixture,
+        string configPath = null) {
+    auto cmd = makeDextoolAnalyze(testEnv)
+        .argDebug(false)
+        .addInputArg(fixture.programCode)
+        .addPostArg(["--mutant", "all"]);
+
+    if (configPath.length != 0)
+        cmd.addPostArg(["-c", configPath]);
+
+    cmd.run;
+}
+
+private auto makeCoverageTestCommand(ref TestEnv testEnv, CoverageFixtureInstance fixture,
+        string configPath, bool throwOnExitStatus = true) {
+    auto cmd = dextool_test.makeDextool(testEnv)
+        .setWorkdir(workDir)
+        .args(["mutate"])
+        .addArg(["test"])
+        .addPostArg(["--db", (testEnv.outdir ~ defaultDb).toString])
+        .addPostArg("--no-skipped")
+        .addPostArg(["--build-cmd", fixture.compileScript])
+        .addPostArg(["--test-cmd", fixture.testScript])
+        .addPostArg(["--log-coverage"])
+        .argDebug(false)
+        .throwOnExitStatus(throwOnExitStatus);
+
+    if (configPath.length != 0)
+        cmd.addPostArg(["-c", configPath]);
+
+    return cmd;
+}
+
+private auto runCoverageTest(ref TestEnv testEnv, CoverageFixtureInstance fixture, string configPath,
+        string[][] extraPostArgs = null, bool throwOnExitStatus = true) {
+    auto cmd = makeCoverageTestCommand(testEnv, fixture, configPath, throwOnExitStatus);
+    foreach (args; extraPostArgs)
+        cmd.addPostArg(args);
+    return cmd.run;
+}
+
+private JSONValue coverageReportStat(ref TestEnv testEnv) {
+    makeDextoolReport(testEnv, testData.dirName)
+        .argDebug(false)
+        .addPostArg(["--style", "json"])
+        .addPostArg(["--section", "summary", "--section", "all_mut"])
+        .addPostArg(["--logdir", testEnv.outdir.toString])
+        .run;
+    return parseJSON(readText((testEnv.outdir ~ "report.json").toString))["stat"];
+}
+
+private void assertCoverageInstrumentationOutput(string[] output) {
+    testAnyOrder!SubStr([
+        "Compiling instrumented source code",
+        "Coverage instrumenting"
+    ]).shouldBeIn(output);
+}
+
+private void assertBuiltInCoverageOutput(string[] output) {
+    assertCoverageInstrumentationOutput(output);
+    testAnyOrder!SubStr([
+        "Importing coverage from gcov --json-format"
+    ]).shouldNotBeIn(output);
+}
+
+private void assertImportedCoverageOutput(string[] output, size_t inputs = 1) {
+    testAnyOrder!SubStr([
+        "Importing coverage from gcov --json-format",
+        format("Imported gcov json coverage (%s inputs,", inputs)
+    ]).shouldBeIn(output);
+    testAnyOrder!SubStr([
+        "Compiling instrumented source code",
+        "Coverage instrumenting"
+    ]).shouldNotBeIn(output);
+}
+
+private uint[] lineStarts(const(ubyte)[] content) {
+    auto starts = appender!(uint[])();
+    starts.put(0);
+    foreach (i, b; content) {
+        if (b == '\n' && i + 1 < content.length)
+            starts.put(cast(uint) (i + 1));
+    }
+    return starts.data;
+}
+
+private uint lineNumberAt(const uint[] starts, uint offset) @safe pure nothrow {
+    if (starts.length == 0)
+        return 1;
+    return cast(uint) (starts.length - assumeSorted(starts).upperBound(offset).length);
+}
+
+private LineRange lineRangeForRegion(Offset region, const uint[] starts) @safe pure nothrow {
+    return LineRange(lineNumberAt(starts, region.begin),
+            lineNumberAt(starts, region.isZero ? region.begin : region.end - 1));
+}
+
+private string regionKey(Offset region) {
+    return format("%s:%s", region.begin, region.end);
+}
+
+private Path dbProgramPath(CoverageFixtureInstance fixture) {
+    const relative = relativePath(fixture.programCode, workDir.toString);
+    return relative == fixture.programCode ? Path("program.cpp") : Path(relative);
+}
+
+private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixtureInstance fixture) {
+    auto db = openDatabase(testEnv);
+    auto allCoverage = db.coverageApi.getCoverageMap;
+    auto fileId = db.getFileId(Path("program.cpp"));
+    if (fileId.isNull)
+        fileId = db.getFileId(dbProgramPath(fixture));
+    if (fileId.isNull && allCoverage.length == 1) {
+        foreach (id; allCoverage.byKey) {
+            fileId = id;
+            break;
+        }
+    }
+    fileId.isNull.shouldBeFalse;
+
+    auto fileRegions = fileId.get in allCoverage;
+    (fileRegions !is null).shouldBeTrue;
+
+    auto knownStatus = db.coverageApi.getCoverageStatus(fileId.get);
+    bool[string] knownByRegion;
+    foreach (status; knownStatus)
+        knownByRegion[regionKey(status.region)] = status.status;
+
+    const starts = lineStarts(cast(const(ubyte)[]) read(fixture.programCode));
+    CoverageView view;
+    foreach (region; *fileRegions) {
+        const key = regionKey(region.region);
+        const lines = lineRangeForRegion(region.region, starts);
+        if (auto status = key in knownByRegion) {
+            view.known ~= CoverageLineStatus(lines, *status);
+        } else {
+            view.unknown ~= lines;
+        }
+    }
+
+    return view;
+}
+
+private bool intersects(LineRange range, uint beginLine, uint endLine) @safe pure nothrow {
+    return !(range.endLine < beginLine || endLine < range.beginLine);
+}
+
+private bool hasKnownStatus(CoverageView view, uint beginLine, uint endLine, bool status) {
+    return view.known.any!(a => a.status == status && intersects(a.lines, beginLine, endLine));
+}
+
+private bool hasUnknownStatus(CoverageView view, uint beginLine, uint endLine) {
+    return view.unknown.any!(a => intersects(a, beginLine, endLine));
+}
+
+private void resetMutantsToUnknown(ref TestEnv testEnv) {
+    auto db = openDatabase(testEnv);
+    foreach (id; db.mutantApi.getAllMutationStatus)
+        db.mutantApi.update(id, Mutation.Status.unknown, ExitStatus(0));
+}
+
+@(testId ~ "shall use built in coverage instrumentation when gcov json is not configured")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig);
+    assertBuiltInCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["alive"].integer.shouldBeGreaterThan(2);
+    stat["killed"].integer.shouldBeGreaterThan(1);
+    stat["no_coverage"].integer.shouldBeGreaterThan(1);
+}
+
+@(testId ~ "shall import gcov json coverage and bypass built in instrumentation")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "simple_coverage.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, fixture.programCode,
+            coverFunctionCoveredLinesWithZeroCount ~ unusedFunctionUncoveredLines
+            ~ mainFunctionCoveredLines, GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["alive"].integer.shouldBeGreaterThan(1);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+    stat["no_coverage"].integer.shouldBeGreaterThan(1);
+}
+
+@(testId ~ "shall map gcov counts to covered uncovered and unknown regions")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "region-status.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, fixture.programCode,
+            coverFunctionCoveredLines ~ unusedFunctionUncoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto coverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
+    hasKnownStatus(coverage, 57, 61, false).shouldBeTrue;
+    hasUnknownStatus(coverage, 64, 69).shouldBeTrue;
+}
+
+@(testId ~ "shall replace old imported coverage on reimport")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const firstJson = (testEnv.outdir ~ "first.gcov.json.gz").toString;
+    const secondJson = (testEnv.outdir ~ "second.gcov.json.gz").toString;
+    writeGcovJson(firstJson, fixture.programCode,
+            coverFunctionCoveredLines ~ unusedFunctionUncoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+    writeGcovJson(secondJson, fixture.programCode,
+            coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    runCoverageTest(testEnv, fixture, defaultCoverageConfig, [["--gcov-json", firstJson]]);
+    auto firstCoverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(firstCoverage, 57, 61, false).shouldBeTrue;
+
+    resetMutantsToUnknown(testEnv);
+
+    auto secondRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", secondJson]]);
+    assertImportedCoverageOutput(secondRun.output);
+
+    auto secondCoverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(secondCoverage, 57, 61, false).shouldBeFalse;
+    hasUnknownStatus(secondCoverage, 57, 61).shouldBeTrue;
+}
+
+@(testId ~ "shall import relative source paths from uncompressed gcov json via cli")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "relative.gcov.json").toString;
+    writeGcovJson(gcovJson, "program.cpp", coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(includeCwd: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+}
+
+@(testId ~ "shall import gcov json when line numbers and counts are strings")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "string_numbers.gcov.json").toString;
+    writeGcovJson(gcovJson, "program.cpp", coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(includeCwd: false, stringifyNumbers: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto coverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
+}
+
+@(testId ~ "shall resolve gcov source paths using current_working_directory from a directory input")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovDir = (testEnv.outdir ~ "coverage").toString;
+    mkdirRecurse(gcovDir);
+    const gcovJson = buildPath(gcovDir, "cwd.gcov.json.gz");
+    writeGcovJson(gcovJson, "program.cpp", coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(cwd: testEnv.outdir.toString, gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovDir]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+}
+
+@(testId ~ "shall import gcov json from single-string toml config using absolute source paths")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "toml.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, absolutePath(fixture.programCode),
+            coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    const configPath = writeConfig(testEnv, "coverage_gcov.toml",
+            coverageConfigText(format(`gcov_json = "%s"`, gcovJson)));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, configPath);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+}
+
+@(testId ~ "shall merge duplicate line counts across multiple gcov json inputs")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const firstJson = (testEnv.outdir ~ "duplicate_first.gcov.json").toString;
+    const secondJson = (testEnv.outdir ~ "duplicate_second.gcov.json").toString;
+    writeGcovJson(firstJson, "program.cpp", coverFunctionCoveredLines,
+            GcovJsonWriteOptions(includeCwd: false));
+    writeGcovJson(secondJson, "program.cpp", withCount(coverFunctionCoveredLines, 0),
+            GcovJsonWriteOptions(includeCwd: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", firstJson], ["--gcov-json", secondJson]]);
+    assertImportedCoverageOutput(testRun.output, 2);
+
+    auto coverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
+}
+
+@(testId ~ "shall warn about malformed gcov file entries and import the valid ones")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "malformed_entry.gcov.json").toString;
+    JSONValue malformed;
+    malformed["file"] = "program.cpp";
+    malformed["lines"] = "not an array";
+    writeGcovJsonFiles(gcovJson, [
+        makeGcovFileData("program.cpp", coverFunctionCoveredLines, GcovJsonWriteOptions(
+                includeCwd: false)),
+        malformed
+    ], GcovJsonWriteOptions(includeCwd: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "Skipping malformed gcov file entry"
+    ]).shouldBeIn(testRun.output);
+
+    auto coverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
+}
+
+@(testId ~ "shall warn and fall back to built in coverage on bad gcov json")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "bad.gcov.json").toString;
+    write(gcovJson, "{ definitely not valid json");
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "Failed to parse gcov json",
+        "None of the gcov json files matched analyzed source files in the current work area."
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when gcov json is missing the files array")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "missing_files.gcov.json").toString;
+    writeGcovJson(gcovJson, fixture.programCode, [],
+            GcovJsonWriteOptions(includeFiles: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "Object 'files' not found in gcov json",
+        "None of the gcov json files matched analyzed source files in the current work area."
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when coverage.gcov_json in toml cannot be parsed")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const configPath = writeConfig(testEnv, "bad_gcov_json_config.toml",
+            coverageConfigText("gcov_json = [1]"));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, configPath, null, false);
+    testRun.success.shouldBeTrue;
+    assertBuiltInCoverageOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "coverage.gcov_json: failed parsing"
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when coverage.gcov_json in toml is a scalar")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const configPath = writeConfig(testEnv, "scalar_gcov_json_config.toml",
+            coverageConfigText("gcov_json = 1"));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, configPath, null, false);
+    testRun.success.shouldBeTrue;
+    assertBuiltInCoverageOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "coverage.gcov_json: failed parsing"
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when gcov json input does not exist")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const missing = (testEnv.outdir ~ "missing.gcov.json.gz").toString;
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", missing]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "gcov json input does not exist",
+        "No gcov json input files were found"
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when gcov json inputs are an empty directory and a wrong file type")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const emptyDir = (testEnv.outdir ~ "empty_coverage").toString;
+    mkdirRecurse(emptyDir);
+    const wrongFile = (testEnv.outdir ~ "not_gcov.json.txt").toString;
+    write(wrongFile, "{}");
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig, [
+        ["--gcov-json", emptyDir], ["--gcov-json", wrongFile]
+    ], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "No gcov json files found in",
+        "gcov json input must end in .gcov.json or .gcov.json.gz",
+        "No gcov json input files were found"
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when analyzed coverage regions are missing")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const noCoverageConfig = writeConfig(testEnv, "analyze_without_coverage.toml",
+            analyzeWithoutCoverageConfigText);
+    const gcovJson = (testEnv.outdir ~ "no_regions.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, fixture.programCode, coverFunctionCoveredLines[0 .. 3],
+            GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, noCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "No analyzed coverage regions found",
+        "Re-run analyze with [coverage].use = true before importing gcov JSON"
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when gcov json does not match analyzed source files")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "no_match.gcov.json").toString;
+    writeGcovJson(gcovJson, "other.cpp", coverFunctionCoveredLines[0 .. 3],
+            GcovJsonWriteOptions(includeCwd: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "None of the gcov json files matched analyzed source files in the current work area."
+    ]).shouldBeIn(testRun.output);
 }

--- a/plugin/mutate/test/test_coverage.d
+++ b/plugin/mutate/test/test_coverage.d
@@ -735,6 +735,35 @@ unittest {
     hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
 }
 
+@(testId ~ "shall warn and clamp negative gcov counts before merging")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const negativeJson = (testEnv.outdir ~ "negative.gcov.json").toString;
+    const positiveJson = (testEnv.outdir ~ "positive.gcov.json").toString;
+    writeGcovJson(negativeJson, "program.cpp",
+            withCount(coverFunctionCoveredLines ~ unusedFunctionUncoveredLines, -1000),
+            GcovJsonWriteOptions(includeCwd: false));
+    writeGcovJson(positiveJson, "program.cpp", withCount(coverFunctionCoveredLines, 1),
+            GcovJsonWriteOptions(includeCwd: false));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig, [
+        ["--gcov-json", negativeJson], ["--gcov-json", positiveJson]
+    ]);
+    assertImportedCoverageOutput(testRun.output, 2);
+    testAnyOrder!SubStr([
+        "(negative) Unexpected negative hit count '-1000'",
+        "while importing from simple_coverage.gcda"
+    ]).shouldBeIn(testRun.output);
+
+    auto coverage = loadCoverageView(testEnv, fixture);
+    hasKnownStatus(coverage, 47, 54, true).shouldBeTrue;
+    hasKnownStatus(coverage, 57, 61, false).shouldBeTrue;
+}
+
 @(testId ~ "shall warn about malformed gcov file entries and import the valid ones")
 unittest {
     mixin(EnvSetup(globalTestdir));

--- a/plugin/mutate/test/test_coverage.d
+++ b/plugin/mutate/test/test_coverage.d
@@ -5,15 +5,16 @@ Author: Joakim Brännström (joakim.brannstrom@gmx.com)
 */
 module dextool_test.test_coverage;
 
-import std.algorithm : any, map;
-import std.array : appender, array;
+import std.algorithm : any, canFind, map;
+import std.array : appender, array, join;
 import std.file : mkdirRecurse, read, readText, write;
 import std.format : format;
 import std.json : JSONValue, parseJSON;
-import std.path : absolutePath, buildPath, relativePath;
+import std.path : absolutePath, buildPath, pathSplitter, relativePath;
 import std.range : assumeSorted;
 import std.zlib : Compress, HeaderFormat;
 
+import dextool.plugin.mutate.backend.database.standalone : Database;
 import dextool.plugin.mutate.backend.type : ExitStatus, Mutation, Offset;
 import dextool.type : Path;
 
@@ -22,6 +23,15 @@ import dextool_test.fixtures;
 
 private final class CoverageFixtureInstance : CoverageFixutre {
     override void test() {
+    }
+}
+
+private final class PreciseImportedCoverageFixture : CoverageFixutre {
+    override void test() {
+    }
+
+    override string programFile() {
+        return (testData ~ "gcov_precise_branch.cpp").toString;
     }
 }
 
@@ -87,8 +97,28 @@ private immutable GcovLineSpec[] mainFunctionCoveredLines = [
     GcovLineSpec(69, 1, "main")
 ];
 
+private immutable GcovLineSpec[] preciseBranchCoveredLines = [
+    GcovLineSpec(2, 1, "compute"),
+    GcovLineSpec(3, 1, "compute")
+];
+
+private immutable GcovLineSpec[] preciseBranchUncoveredLines = [
+    GcovLineSpec(5, 0, "compute")
+];
+
+private immutable GcovLineSpec[] preciseMainCoveredLines = [
+    GcovLineSpec(9, 1, "main"),
+    GcovLineSpec(10, 1, "main")
+];
+
 private CoverageFixtureInstance setupCoverageFixture(ref TestEnv testEnv) {
     auto fixture = new CoverageFixtureInstance;
+    fixture.precondition(testEnv);
+    return fixture;
+}
+
+private PreciseImportedCoverageFixture setupPreciseImportedCoverageFixture(ref TestEnv testEnv) {
+    auto fixture = new PreciseImportedCoverageFixture;
     fixture.precondition(testEnv);
     return fixture;
 }
@@ -124,6 +154,10 @@ mutants = ["lcr", "lcrb", "sdl", "uoi", "dcr"]
 [mutant_test]
 test_cmd_timeout = "10 seconds"
 `;
+}
+
+private string pathToHtmlName(string p) {
+    return p.pathSplitter.join("__");
 }
 
 private JSONValue makeGcovLine(GcovLineSpec spec,
@@ -192,7 +226,7 @@ private GcovLineSpec[] withCount(const(GcovLineSpec)[] lines, long count) {
     return lines.map!(a => GcovLineSpec(a.lineNumber, count, a.functionName)).array;
 }
 
-private void analyzeCoverageProgram(ref TestEnv testEnv, CoverageFixtureInstance fixture,
+private void analyzeCoverageProgram(ref TestEnv testEnv, CoverageFixutre fixture,
         string configPath = null) {
     auto cmd = makeDextoolAnalyze(testEnv)
         .argDebug(false)
@@ -205,7 +239,7 @@ private void analyzeCoverageProgram(ref TestEnv testEnv, CoverageFixtureInstance
     cmd.run;
 }
 
-private auto makeCoverageTestCommand(ref TestEnv testEnv, CoverageFixtureInstance fixture,
+private auto makeCoverageTestCommand(ref TestEnv testEnv, CoverageFixutre fixture,
         string configPath, bool throwOnExitStatus = true) {
     auto cmd = dextool_test.makeDextool(testEnv)
         .setWorkdir(workDir)
@@ -225,7 +259,7 @@ private auto makeCoverageTestCommand(ref TestEnv testEnv, CoverageFixtureInstanc
     return cmd;
 }
 
-private auto runCoverageTest(ref TestEnv testEnv, CoverageFixtureInstance fixture, string configPath,
+private auto runCoverageTest(ref TestEnv testEnv, CoverageFixutre fixture, string configPath,
         string[][] extraPostArgs = null, bool throwOnExitStatus = true) {
     auto cmd = makeCoverageTestCommand(testEnv, fixture, configPath, throwOnExitStatus);
     foreach (args; extraPostArgs)
@@ -241,6 +275,28 @@ private JSONValue coverageReportStat(ref TestEnv testEnv) {
         .addPostArg(["--logdir", testEnv.outdir.toString])
         .run;
     return parseJSON(readText((testEnv.outdir ~ "report.json").toString))["stat"];
+}
+
+private string coverageHtmlProgramPage(ref TestEnv testEnv, CoverageFixutre fixture) {
+    makeDextoolReport(testEnv, testData.dirName)
+        .argDebug(false)
+        .addPostArg(["--style", "html"])
+        .addPostArg(["--section", "summary", "--section", "all_mut"])
+        .addPostArg(["--logdir", testEnv.outdir.toString])
+        .run;
+
+    auto db = openDatabase(testEnv);
+    const fileId = coverageFileId(db, fixture);
+    auto filePath = db.getFile(fileId);
+    filePath.isNull.shouldBeFalse;
+
+    return readText((testEnv.outdir ~ format("html/files/%s.html",
+            pathToHtmlName(filePath.get))).toString);
+}
+
+private void htmlLineShouldHaveCoverageClass(string html, uint line, string cssClass) {
+    html.canFind(format(`id="loc-%s"><span class="line_nr %s">%s:`, line, cssClass, line))
+        .shouldBeTrue;
 }
 
 private void assertCoverageInstrumentationOutput(string[] output) {
@@ -293,13 +349,12 @@ private string regionKey(Offset region) {
     return format("%s:%s", region.begin, region.end);
 }
 
-private Path dbProgramPath(CoverageFixtureInstance fixture) {
+private Path dbProgramPath(CoverageFixutre fixture) {
     const relative = relativePath(fixture.programCode, workDir.toString);
     return relative == fixture.programCode ? Path("program.cpp") : Path(relative);
 }
 
-private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixtureInstance fixture) {
-    auto db = openDatabase(testEnv);
+private auto coverageFileId(ref Database db, CoverageFixutre fixture) {
     auto allCoverage = db.coverageApi.getCoverageMap;
     auto fileId = db.getFileId(Path("program.cpp"));
     if (fileId.isNull)
@@ -312,10 +367,18 @@ private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixtureInstan
     }
     fileId.isNull.shouldBeFalse;
 
-    auto fileRegions = fileId.get in allCoverage;
+    return fileId.get;
+}
+
+private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixutre fixture) {
+    auto db = openDatabase(testEnv);
+    auto allCoverage = db.coverageApi.getCoverageMap;
+    const fileId = coverageFileId(db, fixture);
+
+    auto fileRegions = fileId in allCoverage;
     (fileRegions !is null).shouldBeTrue;
 
-    auto knownStatus = db.coverageApi.getCoverageStatus(fileId.get);
+    auto knownStatus = db.coverageApi.getCoverageStatus(fileId);
     bool[string] knownByRegion;
     foreach (status; knownStatus)
         knownByRegion[regionKey(status.region)] = status.status;
@@ -333,6 +396,28 @@ private CoverageView loadCoverageView(ref TestEnv testEnv, CoverageFixtureInstan
     }
 
     return view;
+}
+
+private bool[uint] loadImportedLineCoverage(ref TestEnv testEnv, CoverageFixutre fixture) {
+    auto db = openDatabase(testEnv);
+    return db.coverageApi.getImportedLineCoverage(coverageFileId(db, fixture));
+}
+
+private Mutation.Status[] mutantStatusesAtLine(ref TestEnv testEnv, CoverageFixutre fixture, uint line) {
+    auto db = openDatabase(testEnv);
+    static immutable sql = "SELECT DISTINCT t0.status FROM mutation_status t0, mutation t1, mutation_point t2 "
+        ~ "WHERE t0.id = t1.st_id AND t1.mp_id = t2.id AND t2.file_id = :fid "
+        ~ "AND :line BETWEEN t2.line AND t2.line_end";
+
+    auto stmt = db.db.prepare(sql);
+    stmt.get.bind(":fid", coverageFileId(db, fixture).get);
+    stmt.get.bind(":line", line);
+
+    auto rval = appender!(Mutation.Status[])();
+    foreach (ref r; stmt.get.execute) {
+        rval.put(cast(Mutation.Status) r.peek!long(0));
+    }
+    return rval.data;
 }
 
 private bool intersects(LineRange range, uint beginLine, uint endLine) @safe pure nothrow {
@@ -391,6 +476,52 @@ unittest {
     stat["no_coverage"].integer.shouldBeGreaterThan(1);
 }
 
+@(testId ~ "shall render imported gcov coverage precisely in the html file report")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupPreciseImportedCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "precise_report.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, fixture.programCode,
+            preciseBranchCoveredLines ~ preciseBranchUncoveredLines ~ preciseMainCoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    const html = coverageHtmlProgramPage(testEnv, fixture);
+    htmlLineShouldHaveCoverageClass(html, 3, "loc_covered");
+    htmlLineShouldHaveCoverageClass(html, 5, "loc_noncovered");
+}
+
+@(testId ~ "shall use imported gcov line coverage when propagating no coverage mutants")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupPreciseImportedCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "precise_no_coverage.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, fixture.programCode,
+            preciseBranchCoveredLines ~ preciseBranchUncoveredLines ~ preciseMainCoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto uncoveredStatuses = mutantStatusesAtLine(testEnv, fixture, 5);
+    uncoveredStatuses.length.shouldBeGreaterThan(0);
+    uncoveredStatuses.canFind(Mutation.Status.noCoverage).shouldBeTrue;
+
+    auto coveredStatuses = mutantStatusesAtLine(testEnv, fixture, 2);
+    coveredStatuses.length.shouldBeGreaterThan(0);
+    coveredStatuses.canFind(Mutation.Status.noCoverage).shouldBeFalse;
+}
+
 @(testId ~ "shall map gcov counts to covered uncovered and unknown regions")
 unittest {
     mixin(EnvSetup(globalTestdir));
@@ -430,7 +561,11 @@ unittest {
 
     runCoverageTest(testEnv, fixture, defaultCoverageConfig, [["--gcov-json", firstJson]]);
     auto firstCoverage = loadCoverageView(testEnv, fixture);
+    auto firstImportedCoverage = loadImportedLineCoverage(testEnv, fixture);
+    auto firstUncoveredLine = 57u in firstImportedCoverage;
     hasKnownStatus(firstCoverage, 57, 61, false).shouldBeTrue;
+    (firstUncoveredLine !is null).shouldBeTrue;
+    (*firstUncoveredLine).shouldBeFalse;
 
     resetMutantsToUnknown(testEnv);
 
@@ -439,8 +574,14 @@ unittest {
     assertImportedCoverageOutput(secondRun.output);
 
     auto secondCoverage = loadCoverageView(testEnv, fixture);
+    auto secondImportedCoverage = loadImportedLineCoverage(testEnv, fixture);
+    auto secondUncoveredLine = 57u in secondImportedCoverage;
+    auto secondCoveredLine = 64u in secondImportedCoverage;
     hasKnownStatus(secondCoverage, 57, 61, false).shouldBeFalse;
     hasUnknownStatus(secondCoverage, 57, 61).shouldBeTrue;
+    (secondUncoveredLine is null).shouldBeTrue;
+    (secondCoveredLine !is null).shouldBeTrue;
+    (*secondCoveredLine).shouldBeTrue;
 }
 
 @(testId ~ "shall import relative source paths from uncompressed gcov json via cli")

--- a/plugin/mutate/test/test_coverage.d
+++ b/plugin/mutate/test/test_coverage.d
@@ -603,6 +603,53 @@ unittest {
     stat["killed"].integer.shouldBeGreaterThan(0);
 }
 
+@(testId ~ "shall enable coverage when gcov json is provided via cli")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "cli_enables_coverage.gcov.json").toString;
+    writeGcovJson(gcovJson, "program.cpp", coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(includeCwd: false));
+
+    const configPath = writeConfig(testEnv, "test_without_coverage_use.toml",
+            analyzeWithoutCoverageConfigText);
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, configPath,
+            [["--gcov-json", gcovJson]]);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+}
+
+@(testId ~ "shall enable coverage when gcov json is provided via toml")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "toml_enables_coverage.gcov.json.gz").toString;
+    writeGcovJson(gcovJson, absolutePath(fixture.programCode),
+            coverFunctionCoveredLines ~ mainFunctionCoveredLines,
+            GcovJsonWriteOptions(gzip: true));
+
+    const configPath = writeConfig(testEnv, "toml_gcov_without_coverage_use.toml",
+            analyzeWithoutCoverageConfigText ~ format(`
+[coverage]
+gcov_json = "%s"
+`, gcovJson));
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, configPath);
+    assertImportedCoverageOutput(testRun.output);
+
+    auto stat = coverageReportStat(testEnv);
+    stat["killed"].integer.shouldBeGreaterThan(0);
+}
+
 @(testId ~ "shall import gcov json when line numbers and counts are strings")
 unittest {
     mixin(EnvSetup(globalTestdir));
@@ -752,6 +799,29 @@ unittest {
     assertCoverageInstrumentationOutput(testRun.output);
     testAnyOrder!SubStr([
         "Object 'files' not found in gcov json",
+        "None of the gcov json files matched analyzed source files in the current work area."
+    ]).shouldBeIn(testRun.output);
+}
+
+@(testId ~ "shall warn and fall back when gcov json files is not an array")
+unittest {
+    mixin(EnvSetup(globalTestdir));
+    auto fixture = setupCoverageFixture(testEnv);
+
+    const gcovJson = (testEnv.outdir ~ "files_not_array.gcov.json").toString;
+    JSONValue root;
+    root["files"] = "not an array";
+    writeGcovJsonRoot(gcovJson, root, false);
+
+    analyzeCoverageProgram(testEnv, fixture, defaultCoverageConfig);
+
+    auto testRun = runCoverageTest(testEnv, fixture, defaultCoverageConfig,
+            [["--gcov-json", gcovJson]], false);
+    testRun.success.shouldBeTrue;
+    assertCoverageInstrumentationOutput(testRun.output);
+    testAnyOrder!SubStr([
+        "Object 'files' in gcov json",
+        "must be an array",
         "None of the gcov json files matched analyzed source files in the current work area."
     ]).shouldBeIn(testRun.output);
 }

--- a/plugin/mutate/testdata/gcov_precise_branch.cpp
+++ b/plugin/mutate/testdata/gcov_precise_branch.cpp
@@ -1,0 +1,11 @@
+int compute(int x) {
+    if (x == 0) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+int main() {
+    return compute(0);
+}


### PR DESCRIPTION
Add optional support for mutate to import coverage from GCC's gcov --json-format output.

If no gcov JSON input is provided, mutate keeps using the existing source instrumentation coverage flow.

- add --gcov-json and [coverage].gcov_json
- map imported line coverage onto analyzed coverage regions
- store imported coverage in the existing coverage tables
- add integration tests and documentation