### PR TITLE
mutate: match html source font with lcov

### DIFF
--- a/plugin/mutate/data/source.css
+++ b/plugin/mutate/data/source.css
@@ -207,6 +207,8 @@ span.xx_label {
 #locs {
     display: block;
     width: max-content;
+    font-family: monospace;
+    font-size: initial;
 }
 #locs  tr{
     display: block;


### PR DESCRIPTION
The purpose of this PR is to make it easier to compare lcov (left) and dextool mutate coverage (right).

Before:
<img width="1538" height="887" alt="before" src="https://github.com/user-attachments/assets/16bd7a6a-bc2f-46d7-9ee7-0de19e5d8521" />

After:
<img width="1538" height="887" alt="after" src="https://github.com/user-attachments/assets/7ac3aa0d-bc26-4eee-88d7-40d822a13afa" />
